### PR TITLE
Aug consensus

### DIFF
--- a/R/compute_consensus.R
+++ b/R/compute_consensus.R
@@ -13,6 +13,14 @@
 #' to discard as burn-in. Defaults to \code{model_fit$burnin}, and must be
 #' provided if \code{model_fit$burnin} does not exist. See \code{\link{assess_convergence}}.
 #'
+#' @param parameter Character string defining the parameter for which to compute the
+#' consensus. Defaults to \code{"rho"}. Available options are \code{"rho"} and \code{"Rtilde"},
+#' with the latter giving consensus rankings for augmented ranks.
+#'
+#' @param assessors When \code{parameter = "rho"}, this integer vector is used to
+#' define the assessors for which to compute the augmented ranking. Defaults to
+#' \code{1L}, which yields augmented rankings for assessor 1.
+#'
 #' @references \insertAllCited{}
 #'
 #'
@@ -20,41 +28,79 @@
 #'
 #' @example /inst/examples/compute_consensus_example.R
 #'
-compute_consensus <- function(model_fit, type = "CP", burnin = model_fit$burnin){
-
-  if(type == "CP"){
-    .compute_cp_consensus(model_fit, burnin = burnin)
-  } else if(type == "MAP"){
-    .compute_map_consensus(model_fit, burnin = burnin)
-  }
-
-
-}
-
-.compute_cp_consensus <- function(model_fit, burnin = model_fit$burnin){
-
-  stopifnot(class(model_fit) == "BayesMallows")
+compute_consensus <- function(model_fit, type = "CP", burnin = model_fit$burnin,
+                              parameter = "rho", assessors = 1L){
 
   if(is.null(burnin)){
     stop("Please specify the burnin.")
   }
-
   stopifnot(burnin < model_fit$nmc)
 
-  # Filter out the pre-burnin iterations
-  df <- dplyr::filter(model_fit$rho, .data$iteration > burnin)
+  stopifnot(class(model_fit) == "BayesMallows")
 
-  # Find the problem dimensions
-  n_rows <- nrow(dplyr::distinct(df, .data$item, .data$cluster))
+  if(parameter == "Rtilde" && !inherits(model_fit$augmented_data, "data.frame")){
+    stop(paste("For augmented ranks, please refit",
+               "model with option 'save_aug = TRUE'."))
+  }
 
-  # Check that there are rows.
-  stopifnot(n_rows > 0)
+  if(parameter == "rho"){
+    # Filter out the pre-burnin iterations
+    df <- dplyr::filter(model_fit$rho, .data$iteration > burnin)
 
-  # Check that the number of rows are consistent with the information in
-  # the model object
-  stopifnot(model_fit$n_clusters * model_fit$n_items == n_rows)
+    # Find the problem dimensions
+    n_rows <- nrow(dplyr::distinct(df, .data$item, .data$cluster))
 
-  # Convert items and clustr to character, since factor levels are not needed in this case
+    # Check that there are rows.
+    stopifnot(n_rows > 0)
+
+    # Check that the number of rows are consistent with the information in
+    # the model object
+    stopifnot(model_fit$n_clusters * model_fit$n_items == n_rows)
+
+    df <- if(type == "CP"){
+      .compute_cp_consensus(df)
+    } else if(type == "MAP"){
+      .compute_map_consensus(df)
+    }
+
+
+  } else if(parameter == "Rtilde"){
+    # Filter out the pre-burnin iterations and get the right assessors
+    df <- dplyr::filter(model_fit$augmented_data, .data$iteration > burnin, .data$assessor %in% assessors)
+
+    # Find the problem dimensions
+    n_rows <- nrow(dplyr::distinct(df, .data$assessor, .data$item))
+
+    # Check that there are rows.
+    stopifnot(n_rows > 0)
+
+    # Check that the number of rows are consistent with the information in
+    # the model object
+    stopifnot(length(assessors) * model_fit$n_items == n_rows)
+
+    # Treat assessors as clusters
+    df <- dplyr::rename(df, cluster = "assessor")
+
+    df <- if(type == "CP"){
+      .compute_cp_consensus(df)
+    } else if(type == "MAP"){
+      .compute_map_consensus(df)
+    }
+
+    if("cluster" %in% names(df)){
+      df <- dplyr::rename(df, assessor = "cluster")
+    }
+
+  }
+
+  return(df)
+
+
+}
+
+.compute_cp_consensus <- function(df){
+
+  # Convert items and cluster to character, since factor levels are not needed in this case
   df <- dplyr::mutate_at(df, dplyr::vars(.data$item, .data$cluster),
                          as.character)
 
@@ -80,13 +126,12 @@ compute_consensus <- function(model_fit, type = "CP", burnin = model_fit$burnin)
   df <- dplyr::ungroup(df)
 
   # If there is only one cluster, we drop the cluster column
-  if(model_fit$n_clusters == 1){
+  if(length(unique(df$cluster)) == 1){
     df <- dplyr::select(df, -.data$cluster)
   }
 
   return(df)
-
-  }
+}
 
 
 # Internal function for finding CP consensus.
@@ -109,7 +154,7 @@ find_cpc <- function(group_df){
 
     # Keep the max only. This filtering must be done after the first filter,
     # since we take the maximum among the filtered values
-    tmp_df <- dplyr::filter(tmp_df, .data$cumprob == max(.data$cumprob))
+    tmp_df <- dplyr::filter(tmp_df, .data$cumprob == max(dplyr::coalesce(.data$cumprob, 0)))
 
     # Add the ranking
     tmp_df <- dplyr::mutate(tmp_df, ranking = i)
@@ -122,19 +167,13 @@ find_cpc <- function(group_df){
   return(result)
 }
 
-.compute_map_consensus <- function(model_fit, burnin = model_fit$burnin){
-
-  if(is.null(burnin)){
-    stop("Please specify the burnin.")
-  }
-
-  df <- dplyr::filter(model_fit$rho, .data$iteration > burnin)
+.compute_map_consensus <- function(df){
 
   # Store the total number of iterations after burnin
   n_samples <- length(unique(df$iteration))
 
   # Spread to get items along columns
-  df <- tidyr::spread(df, key = .data$item, value = .data$value)
+  df <- tidyr::pivot_wider(df, names_from = "item", values_from = "value")
 
   # Group by everything except iteration, and count the unique combinations
   df <- dplyr::group_by_at(df, .vars = dplyr::vars(-.data$iteration))
@@ -151,15 +190,16 @@ find_cpc <- function(group_df){
   df <- dplyr::select(df, -.data$n_max, -.data$n)
 
   # Now collect one set of ranks per cluster
-  df <- tidyr::gather(df, key = "item", value = "map_ranking",
-                      -.data$cluster, -.data$probability)
+  df <- tidyr::pivot_longer(df, cols = -c("cluster", "probability"), names_to = "item", values_to = "map_ranking")
 
   # Sort according to cluster and ranking
   df <- dplyr::arrange(df, .data$cluster, .data$map_ranking)
 
-  if(model_fit$n_clusters == 1){
+  if(length(unique(df$cluster)) == 1){
     df <- dplyr::select(df, -.data$cluster)
   }
+
+
 
   return(df)
 

--- a/R/compute_consensus.R
+++ b/R/compute_consensus.R
@@ -2,7 +2,8 @@
 #'
 #' Compute the consensus ranking using either cumulative probability (CP) or maximum a posteriori (MAP) consensus
 #' \insertCite{vitelli2018}{BayesMallows}. For mixture models, the
-#' consensus is given for each mixture.
+#' consensus is given for each mixture. Consensus of augmented ranks can also be computed
+#' for each assessor, by setting \code{parameter = "Rtilde"}.
 #'
 #' @param model_fit An object returned from \code{\link{compute_mallows}}.
 #'

--- a/inst/examples/compute_consensus_example.R
+++ b/inst/examples/compute_consensus_example.R
@@ -38,3 +38,27 @@ compute_consensus(model_fit, type = "MAP")
   # We now compute the MAP consensus
   map_consensus_df <- compute_consensus(model_fit, type = "MAP")
 }
+
+\dontrun{
+  # CP CONSENSUS FOR AUGMENTED RANKINGS
+  # We use the example dataset with beach preferences.
+  model_fit <- compute_mallows(preferences = beach_preferences, save_aug = TRUE,
+                               aug_thinning = 2, seed = 123L)
+  # We set burnin = 1000
+  model_fit$burnin <- 1000
+  # We now compute the CP consensus of augmented ranks for assessors 1 and 3
+  cp_consensus_df <- compute_consensus(model_fit, type = "CP",
+                                       parameter = "Rtilde", assessors = c(1L, 3L))
+  # We can also compute the MAP consensus for assessor 2
+  map_consensus_df <- compute_consensus(model_fit, type = "MAP",
+                                        parameter = "Rtilde", assessors = 2L)
+
+  # Caution!
+  # With very sparse data or with too few iterations, there may be ties in the MAP consensus
+  # This is illustrated below for the case of only 5 post-burnin iterations. Two MAP rankings are
+  # equally likely in this case (and for this seed).
+  model_fit <- compute_mallows(preferences = beach_preferences, nmc = 1005,
+                               save_aug = TRUE, aug_thinning = 1, seed = 123L)
+  model_fit$burnin <- 1000
+  compute_consensus(model_fit, type = "MAP", parameter = "Rtilde", assessors = 2L)
+}

--- a/man/compute_consensus.Rd
+++ b/man/compute_consensus.Rd
@@ -4,7 +4,13 @@
 \alias{compute_consensus}
 \title{Compute Consensus Ranking}
 \usage{
-compute_consensus(model_fit, type = "CP", burnin = model_fit$burnin)
+compute_consensus(
+  model_fit,
+  type = "CP",
+  burnin = model_fit$burnin,
+  parameter = "rho",
+  assessors = 1L
+)
 }
 \arguments{
 \item{model_fit}{An object returned from \code{\link{compute_mallows}}.}
@@ -15,6 +21,14 @@ compute_consensus(model_fit, type = "CP", burnin = model_fit$burnin)
 \item{burnin}{A numeric value specifying the number of iterations
 to discard as burn-in. Defaults to \code{model_fit$burnin}, and must be
 provided if \code{model_fit$burnin} does not exist. See \code{\link{assess_convergence}}.}
+
+\item{parameter}{Character string defining the parameter for which to compute the
+consensus. Defaults to \code{"rho"}. Available options are \code{"rho"} and \code{"Rtilde"},
+with the latter giving consensus rankings for augmented ranks.}
+
+\item{assessors}{When \code{parameter = "rho"}, this integer vector is used to
+define the assessors for which to compute the augmented ranking. Defaults to
+\code{1L}, which yields augmented rankings for assessor 1.}
 }
 \description{
 Compute the consensus ranking using either cumulative probability (CP) or maximum a posteriori (MAP) consensus
@@ -61,6 +75,30 @@ compute_consensus(model_fit, type = "MAP")
   model_fit$burnin <- 1000
   # We now compute the MAP consensus
   map_consensus_df <- compute_consensus(model_fit, type = "MAP")
+}
+
+\dontrun{
+  # CP CONSENSUS FOR AUGMENTED RANKINGS
+  # We use the example dataset with beach preferences.
+  model_fit <- compute_mallows(preferences = beach_preferences, save_aug = TRUE,
+                               aug_thinning = 2, seed = 123L)
+  # We set burnin = 1000
+  model_fit$burnin <- 1000
+  # We now compute the CP consensus of augmented ranks for assessors 1 and 3
+  cp_consensus_df <- compute_consensus(model_fit, type = "CP",
+                                       parameter = "Rtilde", assessors = c(1L, 3L))
+  # We can also compute the MAP consensus for assessor 2
+  map_consensus_df <- compute_consensus(model_fit, type = "MAP",
+                                        parameter = "Rtilde", assessors = 2L)
+
+  # Caution!
+  # With very sparse data or with too few iterations, there may be ties in the MAP consensus
+  # This is illustrated below for the case of only 5 post-burnin iterations. Two MAP rankings are
+  # equally likely in this case (and for this seed).
+  model_fit <- compute_mallows(preferences = beach_preferences, nmc = 1005,
+                               save_aug = TRUE, aug_thinning = 1, seed = 123L)
+  model_fit$burnin <- 1000
+  compute_consensus(model_fit, type = "MAP", parameter = "Rtilde", assessors = 2L)
 }
 }
 \references{

--- a/man/compute_consensus.Rd
+++ b/man/compute_consensus.Rd
@@ -33,7 +33,8 @@ define the assessors for which to compute the augmented ranking. Defaults to
 \description{
 Compute the consensus ranking using either cumulative probability (CP) or maximum a posteriori (MAP) consensus
 \insertCite{vitelli2018}{BayesMallows}. For mixture models, the
-consensus is given for each mixture.
+consensus is given for each mixture. Consensus of augmented ranks can also be computed
+for each assessor, by setting \code{parameter = "Rtilde"}.
 }
 \examples{
 # The example datasets potato_visual and potato_weighing contain complete

--- a/tests/testthat/test_compute_consensus.R
+++ b/tests/testthat/test_compute_consensus.R
@@ -1,10 +1,181 @@
 context("Testing compute_consensus")
 
-b <- compute_mallows(preferences = beach_preferences, nmc = 500)
+b <- compute_mallows(preferences = beach_preferences, nmc = 500, seed = 123L)
 b$burnin <- 200
 cp <- compute_consensus(b)
 map <- compute_consensus(b, type = "MAP")
 
-expect_true(inherits(cp, "data.frame"))
-expect_true(inherits(map, "data.frame"))
+test_that("compute_consensus returns correct object", {
+  expect_true(inherits(cp, "data.frame"))
+  expect_true(inherits(map, "data.frame"))
 
+})
+
+test_that("compute_consensus computes correctly for rho", {
+  expect_equal(cp, structure(list(ranking = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+                                              12, 13, 14, 15), item = c("Item 9", "Item 6", "Item 3", "Item 11",
+                                                                        "Item 15", "Item 10", "Item 1", "Item 5", "Item 7", "Item 13",
+                                                                        "Item 8", "Item 4", "Item 12", "Item 14", "Item 2"), cumprob = c(0.78,
+                                                                                                                                         1, 1, 0.976666666666667, 0.87, 0.983333333333333, 1, 0.703333333333333,
+                                                                                                                                         1, 1, 0.926666666666667, 0.926666666666667, 1, 0.913333333333333,
+                                                                                                                                         1)), row.names = c(NA, -15L), class = c("tbl_df", "tbl", "data.frame"
+                                                                                                                                         )))
+
+  expect_equal(map, structure(list(probability = c(0.34, 0.34, 0.34, 0.34, 0.34,
+                                                   0.34, 0.34, 0.34, 0.34, 0.34, 0.34, 0.34, 0.34, 0.34, 0.34),
+                                   item = c("Item 9", "Item 6", "Item 3", "Item 11", "Item 15",
+                                            "Item 10", "Item 1", "Item 5", "Item 7", "Item 13", "Item 8",
+                                            "Item 4", "Item 12", "Item 14", "Item 2"), map_ranking = c(1,
+                                                                                                       2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)), row.names = c(NA,
+                                                                                                                                                                       -15L), class = c("tbl_df", "tbl", "data.frame")))
+
+
+})
+
+
+b2 <- compute_mallows(preferences = beach_preferences, nmc = 500, save_aug = TRUE, seed = 123L)
+b3 <- compute_mallows(preferences = beach_preferences, nmc = 500, save_aug = TRUE, aug_thinning = 3, seed = 123L)
+
+test_that("compute_consensus fails when it should", {
+  # Burnin not set
+  expect_error(compute_consensus(b2, type = "CP"))
+  expect_error(compute_consensus(b2, type = "MAP"))
+
+  # Augmented data are missing
+  expect_error(compute_consensus(b, burnin = 200, type = "CP", parameter = "Rtilde"))
+  expect_error(compute_consensus(b, burnin = 200, type = "MAP", parameter = "Rtilde"))
+
+  # Incorrect assessor
+  expect_error(compute_consensus(b2, burnin = 200, type = "CP", parameter = "Rtilde", assessors = 0))
+  expect_error(compute_consensus(b2, burnin = 200, type = "MAP", parameter = "Rtilde", assessors = 0))
+
+})
+
+test_that("compute_consensus computes augmented ranks correctly", {
+  res <- compute_consensus(b2, type = "CP", burnin = 200, parameter = "Rtilde", assessors = 1L)
+  expect_equal(res, structure(list(ranking = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+                                               12, 13, 14, 15), item = c("Item 6", "Item 11", "Item 3", "Item 9",
+                                                                         "Item 10", "Item 15", "Item 1", "Item 12", "Item 7", "Item 13",
+                                                                         "Item 5", "Item 4", "Item 8", "Item 14", "Item 2"), cumprob = c(0.52,
+                                                                                                                                         0.903333333333333, 0.696666666666667, 0.46, 0.683333333333333,
+                                                                                                                                         0.623333333333333, 0.666666666666667, 0.76, 0.67, 0.583333333333333,
+                                                                                                                                         0.433333333333333, 0.53, 0.76, 0.626666666666667, 1)), row.names = c(NA,
+                                                                                                                                                                                                              -15L), class = c("tbl_df", "tbl", "data.frame")))
+
+
+  res <- compute_consensus(b3, type = "CP", burnin = 200, parameter = "Rtilde", assessors = 1L)
+  expect_equal(res, structure(list(ranking = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+                                               12, 13, 14, 15), item = c("Item 6", "Item 11", "Item 3", "Item 9",
+                                                                         "Item 10", "Item 15", "Item 1", "Item 12", "Item 7", "Item 13",
+                                                                         "Item 5", "Item 4", "Item 8", "Item 14", "Item 2"), cumprob = c(0.52,
+                                                                                                                                         0.91, 0.7, 0.46, 0.69, 0.63, 0.67, 0.75, 0.67, 0.58, 0.44, 0.54,
+                                                                                                                                         0.74, 0.62, 1)), row.names = c(NA, -15L), class = c("tbl_df",
+                                                                                                                                                                                             "tbl", "data.frame")))
+
+
+
+  res <- compute_consensus(b2, type = "CP", burnin = 200, parameter = "Rtilde", assessors = c(3L, 5L))
+  expect_equal(res, structure(list(assessor = c("3", "3", "3", "3", "3", "3", "3",
+                                                "3", "3", "3", "3", "3", "3", "3", "3", "5", "5", "5", "5", "5",
+                                                "5", "5", "5", "5", "5", "5", "5", "5", "5", "5"), ranking = c(1,
+                                                                                                               2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 1, 2, 3, 4, 5,
+                                                                                                               6, 7, 8, 9, 10, 11, 12, 13, 14, 15), item = c("Item 9", "Item 6",
+                                                                                                                                                             "Item 15", "Item 1", "Item 3", "Item 11", "Item 10", "Item 7",
+                                                                                                                                                             "Item 13", "Item 14", "Item 8", "Item 5", "Item 2", "Item 12",
+                                                                                                                                                             "Item 4", "Item 9", "Item 6", "Item 10", "Item 11", "Item 5",
+                                                                                                                                                             "Item 4", "Item 3", "Item 14", "Item 15", "Item 1", "Item 7",
+                                                                                                                                                             "Item 8", "Item 2", "Item 12", "Item 13"), cumprob = c(1, 0.916666666666667,
+                                                                                                                                                                                                                    0.733333333333333, 0.363333333333333, 0.506666666666667, 0.57,
+                                                                                                                                                                                                                    0.65, 0.513333333333333, 0.69, 0.6, 0.586666666666667, 0.77,
+                                                                                                                                                                                                                    0.64, 0.67, 1, 0.39, 0.783333333333333, 0.786666666666667, 0.703333333333333,
+                                                                                                                                                                                                                    0.76, 0.73, 0.57, 0.326666666666667, 0.486666666666667, 0.68,
+                                                                                                                                                                                                                    0.78, 0.853333333333333, 0.596666666666667, 0.833333333333333,
+                                                                                                                                                                                                                    1)), row.names = c(NA, -30L), class = c("tbl_df", "tbl", "data.frame"
+                                                                                                                                                                                                                    )))
+
+
+  res <- compute_consensus(b3, type = "CP", burnin = 200, parameter = "Rtilde", assessors = c(3L, 5L))
+  expect_equal(res, structure(list(assessor = c("3", "3", "3", "3", "3", "3", "3",
+                                                "3", "3", "3", "3", "3", "3", "3", "3", "5", "5", "5", "5", "5",
+                                                "5", "5", "5", "5", "5", "5", "5", "5", "5", "5"), ranking = c(1,
+                                                                                                               2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 1, 2, 3, 4, 5,
+                                                                                                               6, 7, 8, 9, 10, 11, 12, 13, 14, 15), item = c("Item 9", "Item 6",
+                                                                                                                                                             "Item 15", "Item 1", "Item 3", "Item 11", "Item 10", "Item 7",
+                                                                                                                                                             "Item 13", "Item 14", "Item 8", "Item 5", "Item 2", "Item 12",
+                                                                                                                                                             "Item 4", "Item 9", "Item 6", "Item 10", "Item 11", "Item 5",
+                                                                                                                                                             "Item 4", "Item 3", "Item 14", "Item 15", "Item 1", "Item 7",
+                                                                                                                                                             "Item 8", "Item 2", "Item 12", "Item 13"), cumprob = c(1, 0.92,
+                                                                                                                                                                                                                    0.75, 0.36, 0.52, 0.56, 0.64, 0.52, 0.7, 0.61, 0.57, 0.78, 0.64,
+                                                                                                                                                                                                                    0.68, 1, 0.38, 0.79, 0.78, 0.71, 0.75, 0.73, 0.57, 0.33, 0.48,
+                                                                                                                                                                                                                    0.66, 0.78, 0.85, 0.6, 0.84, 1)), row.names = c(NA, -30L), class = c("tbl_df",
+                                                                                                                                                                                                                                                                                         "tbl", "data.frame")))
+
+
+
+  res <- compute_consensus(b2, type = "MAP", burnin = 200, parameter = "Rtilde", assessors = 1L)
+  expect_equal(res, structure(list(probability = c(0.0433333333333333, 0.0433333333333333,
+                                                   0.0433333333333333, 0.0433333333333333, 0.0433333333333333, 0.0433333333333333,
+                                                   0.0433333333333333, 0.0433333333333333, 0.0433333333333333, 0.0433333333333333,
+                                                   0.0433333333333333, 0.0433333333333333, 0.0433333333333333, 0.0433333333333333,
+                                                   0.0433333333333333), item = c("Item 6", "Item 11", "Item 3",
+                                                                                 "Item 9", "Item 10", "Item 15", "Item 1", "Item 12", "Item 7",
+                                                                                 "Item 13", "Item 4", "Item 5", "Item 8", "Item 2", "Item 14"),
+                                   map_ranking = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
+                                                   14, 15)), row.names = c(NA, -15L), class = c("tbl_df", "tbl",
+                                                                                                "data.frame")))
+
+
+  res <- compute_consensus(b3, type = "MAP", burnin = 200, parameter = "Rtilde", assessors = 1L)
+  expect_equal(res, structure(list(probability = c(0.05, 0.05, 0.05, 0.05, 0.05,
+                                                   0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05),
+                                   item = c("Item 6", "Item 11", "Item 3", "Item 9", "Item 10",
+                                            "Item 15", "Item 1", "Item 12", "Item 7", "Item 13", "Item 4",
+                                            "Item 5", "Item 8", "Item 2", "Item 14"), map_ranking = c(1,
+                                                                                                      2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)), row.names = c(NA,
+                                                                                                                                                                      -15L), class = c("tbl_df", "tbl", "data.frame")))
+
+
+
+  res <- compute_consensus(b2, type = "MAP", burnin = 200, parameter = "Rtilde", assessors = c(5L, 3L))
+  expect_equal(res, structure(list(assessor = c(3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                                                3, 3, 3, 3, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5), probability = c(0.0333333333333333,
+                                                                                                                          0.0333333333333333, 0.0333333333333333, 0.0333333333333333, 0.0333333333333333,
+                                                                                                                          0.0333333333333333, 0.0333333333333333, 0.0333333333333333, 0.0333333333333333,
+                                                                                                                          0.0333333333333333, 0.0333333333333333, 0.0333333333333333, 0.0333333333333333,
+                                                                                                                          0.0333333333333333, 0.0333333333333333, 0.0266666666666667, 0.0266666666666667,
+                                                                                                                          0.0266666666666667, 0.0266666666666667, 0.0266666666666667, 0.0266666666666667,
+                                                                                                                          0.0266666666666667, 0.0266666666666667, 0.0266666666666667, 0.0266666666666667,
+                                                                                                                          0.0266666666666667, 0.0266666666666667, 0.0266666666666667, 0.0266666666666667,
+                                                                                                                          0.0266666666666667), item = c("Item 9", "Item 6", "Item 15",
+                                                                                                                                                        "Item 10", "Item 3", "Item 1", "Item 7", "Item 11", "Item 13",
+                                                                                                                                                        "Item 5", "Item 14", "Item 2", "Item 4", "Item 12", "Item 8",
+                                                                                                                                                        "Item 9", "Item 6", "Item 10", "Item 11", "Item 5", "Item 4",
+                                                                                                                                                        "Item 3", "Item 1", "Item 15", "Item 8", "Item 2", "Item 7",
+                                                                                                                                                        "Item 14", "Item 13", "Item 12"), map_ranking = c(1, 2, 3, 4,
+                                                                                                                                                                                                          5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 1, 2, 3, 4, 5, 6, 7, 8,
+                                                                                                                                                                                                          9, 10, 11, 12, 13, 14, 15)), row.names = c(NA, -30L), class = c("tbl_df",
+                                                                                                                                                                                                                                                                          "tbl", "data.frame")))
+
+
+  res <- compute_consensus(b3, type = "MAP", burnin = 200, parameter = "Rtilde", assessors = c(5L, 3L))
+
+  expect_equal(res, structure(list(assessor = c(3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+                                                3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 5, 5,
+                                                5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5), probability = c(0.03,
+                                                                                                        0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03,
+                                                                                                        0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03,
+                                                                                                        0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03,
+                                                                                                        0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03
+                                                ), item = c("Item 9", "Item 9", "Item 6", "Item 6", "Item 15",
+                                                            "Item 15", "Item 10", "Item 11", "Item 3", "Item 13", "Item 1",
+                                                            "Item 1", "Item 7", "Item 14", "Item 11", "Item 3", "Item 13",
+                                                            "Item 7", "Item 5", "Item 10", "Item 14", "Item 5", "Item 2",
+                                                            "Item 8", "Item 4", "Item 2", "Item 12", "Item 4", "Item 8",
+                                                            "Item 12", "Item 9", "Item 6", "Item 10", "Item 11", "Item 5",
+                                                            "Item 4", "Item 3", "Item 1", "Item 15", "Item 8", "Item 2",
+                                                            "Item 7", "Item 14", "Item 13", "Item 12"), map_ranking = c(1,
+                                                                                                                        1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11,
+                                                                                                                        11, 12, 12, 13, 13, 14, 14, 15, 15, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                                                                                                                        10, 11, 12, 13, 14, 15)), row.names = c(NA, -45L), class = c("tbl_df",
+                                                                                                                                                                                     "tbl", "data.frame")))
+    })


### PR DESCRIPTION
Added functionality for computing CP and MAP consensus of augmented rankings, per assessor. These can be obtained with the argument `parameter = "Rtilde"` to `compute_consensus()`. Documentation, examples, and unit tests have been added.