### PR TITLE
Added verbose switch to SMC functions (fixes #73)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,8 +20,12 @@ Authors@R: c(person("Oystein", "Sorensen",
                    email = "cristina.mollica@uniroma1.it",
                    role = c("aut")),
             person("Luca", "Tardella",
-                   role = c("aut"))
-                    )
+                   role = c("aut")),
+            person("Anja", "Stein",
+                   role = c("aut")),
+            person("Waldir", "Leoncio",
+                   email = "w.l.netto@medisin.uio.no",
+                   role = c("ctr")))
 Maintainer: Oystein Sorensen <oystein.sorensen.1985@gmail.com>
 Description: An implementation of the Bayesian version of the Mallows rank model
     (Vitelli et al., Journal of Machine Learning Research, 2018 <https://jmlr.org/papers/v18/15-481.html>;

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BayesMallows
 Type: Package
 Title: Bayesian Preference Learning with the Mallows Rank Model
-Version: 1.0.1.9002
+Version: 1.0.1.9003
 Authors@R: c(person("Oystein", "Sorensen",
                     email = "oystein.sorensen.1985@gmail.com",
                     role = c("aut", "cre"),

--- a/R/smc_get_mallows_loglik.R
+++ b/R/smc_get_mallows_loglik.R
@@ -12,6 +12,7 @@
 #' @param rankings # TODO: describe
 #' @return Mallows log-likelihood
 #' @export
+#' @author Anja Stein
 #' @examples
 #' set.seed(101)
 #' rho <- c(1,2,3,4,5,6)

--- a/R/smc_leap_and_shift_probs.R
+++ b/R/smc_leap_and_shift_probs.R
@@ -19,6 +19,7 @@
 #' leap_and_shift_probs(rho = rho, n_items = n_items, leap_size = 1)
 #' leap_and_shift_probs(rho = rho, n_items = n_items, leap_size = 2)
 #' leap_and_shift_probs(rho = rho, n_items = n_items, leap_size = 3)
+#' @author Anja Stein
 #'
 leap_and_shift_probs <- function(rho, leap_size, n_items) {
 

--- a/R/smc_mallows_new_users_complete.R
+++ b/R/smc_mallows_new_users_complete.R
@@ -14,11 +14,11 @@
 #' \code{\link{estimate_partition_function}} in the BayesMallow R package {estimate_partition_function}.
 #' @param mcmc_kernel_app Interger value for the number of applications we apply the MCMC move kernel
 #' @param num_new_obs Integer value for the number of new observations (complete rankings) for each time step
+#' @param verbose Logical specifying whether to print out the progress of the
+#'   SMC-Mallows algorithm. Defaults to \code{FALSE}.
 #' @return a set of particles each containing a value of rho and alpha
 #' @importFrom stats rexp
-smc_mallows_new_users_complete <- function(R_obs, n_items, metric, leap_size, N, Time, logz_estimate, mcmc_kernel_app, num_new_obs) {
-  # TODO: #73 add verbose switch to suppress output, change print() to message()/cat()
-
+smc_mallows_new_users_complete <- function(R_obs, n_items, metric, leap_size, N, Time, logz_estimate, mcmc_kernel_app, num_new_obs, verbose=FALSE) {
 
   ######################
   ## Initialise Phase
@@ -42,7 +42,7 @@ smc_mallows_new_users_complete <- function(R_obs, n_items, metric, leap_size, N,
   num_obs <- 0
 
   for (tt in 1:Time) {
-    print(paste("observe", tt, "out of", Time))
+    if (verbose) message(paste("observe", tt, "out of", Time))
 
     # keep tally of how many ranking observations we have so far
     num_obs <- num_obs + num_new_obs

--- a/R/smc_metropolis_hastings_alpha.R
+++ b/R/smc_metropolis_hastings_alpha.R
@@ -14,6 +14,7 @@
 #' \code{\link{estimate_partition_function}} in the BayesMallow R package {estimate_partition_function}.
 #' @return \code{alpha} or \code{alpha_prime}: Numeric value to be used as the proposal of a new alpha
 #' @importFrom stats dexp rlnorm runif
+#' @author Anja Stein
 #' @export
 metropolis_hastings_alpha <- function(alpha, n_items, rankings, metric, rho, logz_estimate) {
 

--- a/R/smc_metropolis_hastings_rho.R
+++ b/R/smc_metropolis_hastings_rho.R
@@ -11,6 +11,7 @@
 #' @param metric # TODO: describe
 #' @return \code{rho} or \code{rho_prime}: A ranking sequence vector to be the next value of rho in the MCMC chain
 #' @export
+#' @author Anja Stein
 #' @examples
 #' rho <- c(1,2,3,4,5,6)
 #' alpha <- 2

--- a/R/smc_post_processing_functions.R
+++ b/R/smc_post_processing_functions.R
@@ -402,7 +402,8 @@ compute_consensus_edited <- function(model_fit, type, burnin) {
 #' @description posterior confidence intervals for rho
 #' @inheritParams plot_rho_trace
 #' @param burnin burn-in
-compute_posterior_intervals_rho <- function(output, nmc, burnin) {
+#' @param verbose if \code{TRUE}, prints the final output even if the function is assigned to an object. Defaults to \code{FALSE}.
+compute_posterior_intervals_rho <- function(output, nmc, burnin, verbose=FALSE) {
   smc_plot <- smc_processing(output = output)
   smc_plot$n_clusters <- 1
   smc_plot$cluster <- "Cluster 1"
@@ -411,8 +412,7 @@ compute_posterior_intervals_rho <- function(output, nmc, burnin) {
     model_fit = smc_plot, burnin = burnin,
     parameter = "rho", level = 0.95, decimals = 2
   )
-  # TODO: #73 add verbose switch to suppress output, change print() to message()/cat()
-  print(rho_posterior_interval)
+  if(verbose) print(rho_posterior_interval)
   return(rho_posterior_interval)
 }
 
@@ -421,7 +421,7 @@ compute_posterior_intervals_rho <- function(output, nmc, burnin) {
 #' @inheritParams compute_posterior_intervals_rho
 #' @param C C
 #' @param type type
-compute_rho_consensus <- function(output, nmc, burnin, C, type) {
+compute_rho_consensus <- function(output, nmc, burnin, C, type, verbose=FALSE) {
   n_items <- dim(output)[2]
   smc_plot <- smc_processing(output = output)
 
@@ -435,12 +435,15 @@ compute_rho_consensus <- function(output, nmc, burnin, C, type) {
 
   # rho estimation using cumulative probability
   if (type == "CP") {
-    results <- compute_consensus_edited(model_fit = smc_plot, type = "CP", burnin = burnin)
-    print(results)
+    results <- compute_consensus_edited(
+      model_fit = smc_plot, type = "CP", burnin = burnin
+    )
   } else {
-    results <- compute_consensus_edited(model_fit = smc_plot, type = "MAP", burnin = burnin)
-    print(results)
+    results <- compute_consensus_edited(
+      model_fit = smc_plot, type = "MAP", burnin = burnin
+    )
   }
+  if (verbose) print(results)
 
   return(results)
 }
@@ -448,7 +451,7 @@ compute_rho_consensus <- function(output, nmc, burnin, C, type) {
 #' @title Plot Alpha Posterior
 #' @description posterior for alpha
 #' @inheritParams compute_posterior_intervals_rho
-plot_alpha_posterior <- function(output, nmc, burnin) {
+plot_alpha_posterior <- function(output, nmc, burnin, verbose=FALSE) {
   alpha_samples_table <- data.frame(iteration = 1:nmc, value = output)
   # final_alpha_chain = alpha_mcmc_samples_all[(burnin+1):nmc,]
   # df_alpha_posterior = gather(final_alpha_chain, value = "value", -iteration)
@@ -461,14 +464,14 @@ plot_alpha_posterior <- function(output, nmc, burnin) {
     ggplot2::ggtitle(label = "Implemented SMC scheme") +
     ggplot2::theme(plot.title = ggplot2::element_text(hjust = 0.5))
 
-  print(plot_posterior_alpha)
+  if (verbose) print(plot_posterior_alpha)
   # return(alpha_samples_table)
 }
 
 #' @title Compute Posterior Intervals Alpha
 #' @description posterior confidence intervals
 #' @inheritParams compute_posterior_intervals_rho
-compute_posterior_intervals_alpha <- function(output, nmc, burnin) {
+compute_posterior_intervals_alpha <- function(output, nmc, burnin, verbose=FALSE) {
   alpha_samples_table <- data.frame(iteration = 1:nmc, value = output)
   alpha_samples_table$n_clusters <- 1
   alpha_samples_table$cluster <- "Cluster 1"
@@ -478,6 +481,6 @@ compute_posterior_intervals_alpha <- function(output, nmc, burnin) {
     burnin = burnin,
     parameter = "alpha", level = 0.95, decimals = 2
   )
-  print(alpha_mixture_posterior_interval)
+  if (verbose) print(alpha_mixture_posterior_interval)
   return(alpha_mixture_posterior_interval)
 }

--- a/R/smc_post_processing_functions.R
+++ b/R/smc_post_processing_functions.R
@@ -3,6 +3,7 @@
 # Analysis
 
 #' @title SMC Processing
+#' @author Anja Stein
 #' @param output output
 smc_processing <- function(output) {
   #FIXME: depends on `n_items`, which is out of scope (#68)
@@ -20,6 +21,7 @@ smc_processing <- function(output) {
 }
 
 #' @title Plot rho trace
+#' @author Anja Stein
 #' @inheritParams smc_processing
 #' @param nmc nmc
 plot_rho_trace <- function(output, nmc) {
@@ -244,6 +246,8 @@ compute_posterior_intervals_edited <- function(model_fit, burnin = model_fit$bur
 #' @param burnin A numeric value specifying the number of iterations
 #' to discard as burn-in. Defaults to \code{model_fit$burnin}, and must be
 #' provided if \code{model_fit$burnin} does not exist. See \code{\link{assess_convergence}}.
+#' @author Anja Stein
+#'
 compute_consensus_edited <- function(model_fit, type, burnin) {
   if (type == "CP") {
     stop("Not yet implemented")
@@ -403,6 +407,8 @@ compute_consensus_edited <- function(model_fit, type, burnin) {
 #' @inheritParams plot_rho_trace
 #' @param burnin burn-in
 #' @param verbose if \code{TRUE}, prints the final output even if the function is assigned to an object. Defaults to \code{FALSE}.
+#' @author Anja Stein
+#'
 compute_posterior_intervals_rho <- function(output, nmc, burnin, verbose=FALSE) {
   smc_plot <- smc_processing(output = output)
   smc_plot$n_clusters <- 1
@@ -421,6 +427,8 @@ compute_posterior_intervals_rho <- function(output, nmc, burnin, verbose=FALSE) 
 #' @inheritParams compute_posterior_intervals_rho
 #' @param C C
 #' @param type type
+#' @author Anja Stein
+#'
 compute_rho_consensus <- function(output, nmc, burnin, C, type, verbose=FALSE) {
   n_items <- dim(output)[2]
   smc_plot <- smc_processing(output = output)
@@ -451,6 +459,8 @@ compute_rho_consensus <- function(output, nmc, burnin, C, type, verbose=FALSE) {
 #' @title Plot Alpha Posterior
 #' @description posterior for alpha
 #' @inheritParams compute_posterior_intervals_rho
+#' @author Anja Stein
+#'
 plot_alpha_posterior <- function(output, nmc, burnin, verbose=FALSE) {
   alpha_samples_table <- data.frame(iteration = 1:nmc, value = output)
   # final_alpha_chain = alpha_mcmc_samples_all[(burnin+1):nmc,]
@@ -471,6 +481,8 @@ plot_alpha_posterior <- function(output, nmc, burnin, verbose=FALSE) {
 #' @title Compute Posterior Intervals Alpha
 #' @description posterior confidence intervals
 #' @inheritParams compute_posterior_intervals_rho
+#' @author Anja Stein
+#'
 compute_posterior_intervals_alpha <- function(output, nmc, burnin, verbose=FALSE) {
   alpha_samples_table <- data.frame(iteration = 1:nmc, value = output)
   alpha_samples_table$n_clusters <- 1

--- a/man/compute_consensus_edited.Rd
+++ b/man/compute_consensus_edited.Rd
@@ -21,3 +21,6 @@ Compute the consensus ranking using either cumulative probability (CP) or maximu
 \insertCite{vitelli2018}{BayesMallows}. For mixture models, the
 consensus is given for each mixture.
 }
+\author{
+Anja Stein
+}

--- a/man/compute_posterior_intervals_alpha.Rd
+++ b/man/compute_posterior_intervals_alpha.Rd
@@ -18,3 +18,6 @@ compute_posterior_intervals_alpha(output, nmc, burnin, verbose = FALSE)
 \description{
 posterior confidence intervals
 }
+\author{
+Anja Stein
+}

--- a/man/compute_posterior_intervals_alpha.Rd
+++ b/man/compute_posterior_intervals_alpha.Rd
@@ -4,7 +4,7 @@
 \alias{compute_posterior_intervals_alpha}
 \title{Compute Posterior Intervals Alpha}
 \usage{
-compute_posterior_intervals_alpha(output, nmc, burnin)
+compute_posterior_intervals_alpha(output, nmc, burnin, verbose = FALSE)
 }
 \arguments{
 \item{output}{output}
@@ -12,6 +12,8 @@ compute_posterior_intervals_alpha(output, nmc, burnin)
 \item{nmc}{nmc}
 
 \item{burnin}{burn-in}
+
+\item{verbose}{if \code{TRUE}, prints the final output even if the function is assigned to an object. Defaults to \code{FALSE}.}
 }
 \description{
 posterior confidence intervals

--- a/man/compute_posterior_intervals_rho.Rd
+++ b/man/compute_posterior_intervals_rho.Rd
@@ -18,3 +18,6 @@ compute_posterior_intervals_rho(output, nmc, burnin, verbose = FALSE)
 \description{
 posterior confidence intervals for rho
 }
+\author{
+Anja Stein
+}

--- a/man/compute_posterior_intervals_rho.Rd
+++ b/man/compute_posterior_intervals_rho.Rd
@@ -4,7 +4,7 @@
 \alias{compute_posterior_intervals_rho}
 \title{Compute Posterior Intervals Rho}
 \usage{
-compute_posterior_intervals_rho(output, nmc, burnin)
+compute_posterior_intervals_rho(output, nmc, burnin, verbose = FALSE)
 }
 \arguments{
 \item{output}{output}
@@ -12,6 +12,8 @@ compute_posterior_intervals_rho(output, nmc, burnin)
 \item{nmc}{nmc}
 
 \item{burnin}{burn-in}
+
+\item{verbose}{if \code{TRUE}, prints the final output even if the function is assigned to an object. Defaults to \code{FALSE}.}
 }
 \description{
 posterior confidence intervals for rho

--- a/man/compute_rho_consensus.Rd
+++ b/man/compute_rho_consensus.Rd
@@ -22,3 +22,6 @@ compute_rho_consensus(output, nmc, burnin, C, type, verbose = FALSE)
 \description{
 MAP AND CP consensus ranking estimates
 }
+\author{
+Anja Stein
+}

--- a/man/compute_rho_consensus.Rd
+++ b/man/compute_rho_consensus.Rd
@@ -4,7 +4,7 @@
 \alias{compute_rho_consensus}
 \title{Compute rho consensus}
 \usage{
-compute_rho_consensus(output, nmc, burnin, C, type)
+compute_rho_consensus(output, nmc, burnin, C, type, verbose = FALSE)
 }
 \arguments{
 \item{output}{output}
@@ -16,6 +16,8 @@ compute_rho_consensus(output, nmc, burnin, C, type)
 \item{C}{C}
 
 \item{type}{type}
+
+\item{verbose}{if \code{TRUE}, prints the final output even if the function is assigned to an object. Defaults to \code{FALSE}.}
 }
 \description{
 MAP AND CP consensus ranking estimates

--- a/man/get_mallows_loglik.Rd
+++ b/man/get_mallows_loglik.Rd
@@ -53,3 +53,6 @@ get_mallows_loglik(
   metric = metric
 )
 }
+\author{
+Anja Stein
+}

--- a/man/leap_and_shift_probs.Rd
+++ b/man/leap_and_shift_probs.Rd
@@ -32,5 +32,7 @@ n_items <- 6
 leap_and_shift_probs(rho = rho, n_items = n_items, leap_size = 1)
 leap_and_shift_probs(rho = rho, n_items = n_items, leap_size = 2)
 leap_and_shift_probs(rho = rho, n_items = n_items, leap_size = 3)
-
+}
+\author{
+Anja Stein
 }

--- a/man/metropolis_hastings_alpha.Rd
+++ b/man/metropolis_hastings_alpha.Rd
@@ -31,3 +31,6 @@ Bayesian Mallows Model. Available options are \code{"footrule"},
 \description{
 Function to perform Metropolis-Hastings for new alpha under the Mallows model
 }
+\author{
+Anja Stein
+}

--- a/man/metropolis_hastings_rho.Rd
+++ b/man/metropolis_hastings_rho.Rd
@@ -58,3 +58,6 @@ metropolis_hastings_rho(
 )
 
 }
+\author{
+Anja Stein
+}

--- a/man/plot_alpha_posterior.Rd
+++ b/man/plot_alpha_posterior.Rd
@@ -4,7 +4,7 @@
 \alias{plot_alpha_posterior}
 \title{Plot Alpha Posterior}
 \usage{
-plot_alpha_posterior(output, nmc, burnin)
+plot_alpha_posterior(output, nmc, burnin, verbose = FALSE)
 }
 \arguments{
 \item{output}{output}
@@ -12,6 +12,8 @@ plot_alpha_posterior(output, nmc, burnin)
 \item{nmc}{nmc}
 
 \item{burnin}{burn-in}
+
+\item{verbose}{if \code{TRUE}, prints the final output even if the function is assigned to an object. Defaults to \code{FALSE}.}
 }
 \description{
 posterior for alpha

--- a/man/plot_alpha_posterior.Rd
+++ b/man/plot_alpha_posterior.Rd
@@ -18,3 +18,6 @@ plot_alpha_posterior(output, nmc, burnin, verbose = FALSE)
 \description{
 posterior for alpha
 }
+\author{
+Anja Stein
+}

--- a/man/plot_rho_trace.Rd
+++ b/man/plot_rho_trace.Rd
@@ -14,3 +14,6 @@ plot_rho_trace(output, nmc)
 \description{
 Plot rho trace
 }
+\author{
+Anja Stein
+}

--- a/man/smc_mallows_new_users_complete.Rd
+++ b/man/smc_mallows_new_users_complete.Rd
@@ -13,7 +13,8 @@ smc_mallows_new_users_complete(
   Time,
   logz_estimate,
   mcmc_kernel_app,
-  num_new_obs
+  num_new_obs,
+  verbose = FALSE
 )
 }
 \arguments{
@@ -39,6 +40,9 @@ proposal distribution}
 \item{mcmc_kernel_app}{Interger value for the number of applications we apply the MCMC move kernel}
 
 \item{num_new_obs}{Integer value for the number of new observations (complete rankings) for each time step}
+
+\item{verbose}{Logical specifying whether to print out the progress of the
+SMC-Mallows algorithm. Defaults to \code{FALSE}.}
 }
 \value{
 a set of particles each containing a value of rho and alpha

--- a/man/smc_processing.Rd
+++ b/man/smc_processing.Rd
@@ -12,3 +12,6 @@ smc_processing(output)
 \description{
 SMC Processing
 }
+\author{
+Anja Stein
+}


### PR DESCRIPTION
`verbose` defaults to `FALSE` following precedent found in other BayesMallows functions (e.g. `compute_mallows()`).
