### PR TITLE
Fix TravisCI checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ dist: xenial
 os: linux
 cache: packages
 
+apt_packages:
+  - libmpfr-dev
+
 r_github_packages:
   - jimhester/covr
 


### PR DESCRIPTION
Adds the installation of Ubuntu package libxml2-dev. Credit goes to Daniel Grose for debugging.
