### PR TITLE
Rand init

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BayesMallows
 Type: Package
 Title: Bayesian Preference Learning with the Mallows Rank Model
-Version: 1.0.1
+Version: 1.0.1.9000
 Authors@R: c(person("Oystein", "Sorensen", 
                     email = "oystein.sorensen.1985@gmail.com", 
                     role = c("aut", "cre"),

--- a/R/all_topological_sorts.R
+++ b/R/all_topological_sorts.R
@@ -1,0 +1,22 @@
+# Translation to R of C++ and Python code found here
+# https://www.geeksforgeeks.org/all-topological-sorts-of-a-directed-acyclic-graph/
+all_topological_sorts <- function(graph, path, discovered, n_items){
+  flag <- FALSE
+
+  for(i in seq_len(n_items)){
+    if(attr(graph, "indegree")[[i]] == 0 && !discovered[[i]]){
+      attr(graph, "indegree")[graph[[i]]] <- attr(graph, "indegree")[graph[[i]]] - 1
+
+      path <- c(path, i)
+      discovered[[i]] <- TRUE
+      all_topological_sorts(graph, path, discovered, n_items)
+
+      attr(graph, "indegree")[graph[[i]]] <- attr(graph, "indegree")[graph[[i]]] + 1
+      path <- path[-length(path)]
+      discovered[[i]] <- FALSE
+
+      flag <- TRUE
+    }
+  }
+  if(length(path) == n_items) print(path)
+}

--- a/R/generate_initial_ranking.R
+++ b/R/generate_initial_ranking.R
@@ -20,6 +20,15 @@
 #' @return A matrix of rankings which can be given in the \code{rankings} argument
 #' to \code{\link{compute_mallows}}.
 #'
+#' @note Setting \code{random=TRUE} means that all possible orderings of each assessor's
+#' preferences are generated, and one of them is picked at random. This can be useful
+#' when experiencing convergence issues, e.g., if the MCMC algorithm does not mixed
+#' properly. However, finding all possible orderings is a combinatorial problem,
+#' which may be computationally very hard. The result may not even be possible to fit in
+#' memory, which may cause the R session to crash. When using this option,
+#' please try to increase the size of the problem incrementally, by starting with smaller
+#' subsets of the complete data. An example is given below.
+#'
 #' @export
 #'
 #' @example /inst/examples/generate_initial_ranking_example.R

--- a/R/generate_initial_ranking.R
+++ b/R/generate_initial_ranking.R
@@ -13,6 +13,9 @@
 #' @param cl Optional computing cluster used for parallelization, returned
 #' from \code{parallel::makeCluster}. Defaults to \code{NULL}.
 #'
+#' @param random Logical specifying whether or not to use a random initial ranking.
+#'   Defaults to \code{FALSE}.
+#'
 #'
 #' @return A matrix of rankings which can be given in the \code{rankings} argument
 #' to \code{\link{compute_mallows}}.
@@ -23,7 +26,7 @@
 #'
 generate_initial_ranking <- function(tc,
                                      n_items = max(tc[, c("bottom_item", "top_item")]),
-                                     cl = NULL){
+                                     cl = NULL, random = FALSE){
 
 
   if(!("BayesMallowsTC" %in% class(tc))){
@@ -44,7 +47,7 @@ generate_initial_ranking <- function(tc,
 
 create_ranks <- function(mat, n_items){
   g <- igraph::graph_from_edgelist(mat)
-  g <- as.integer(igraph::topological.sort(g))
+  g <- as.integer(igraph::topo_sort(g))
 
   # Add unranked elements at the end
   all_items <- seq(from = 1, to = n_items, by = 1)

--- a/inst/examples/generate_initial_ranking_example.R
+++ b/inst/examples/generate_initial_ranking_example.R
@@ -1,4 +1,4 @@
-# The example dataset beach_preferences contains pairwise prefences of beach.
+# The example dataset beach_preferences contains pairwise preferences of beach.
 # We must first generate the transitive closure
 beach_tc <- generate_transitive_closure(beach_preferences)
 
@@ -12,6 +12,15 @@ head(beach_init)
 # to get nicer posterior plots:
 colnames(beach_init) <- paste("Beach", seq(from = 1, to = ncol(beach_init), by = 1))
 head(beach_init)
+
+# It is also possible to pick a random sample among all topological sorts.
+# This requires first enumerating all possible sorts, and might hence be computationally
+# demanding. Here is an example, where we reduce the data considerable to speed up computation.
+small_tc <- beach_tc[beach_tc$assessor %in% 1:6 & beach_tc$bottom_item %in% 1:4 & beach_tc$top_item %in% 1:4, ]
+set.seed(123)
+init_small <- generate_initial_ranking(tc = small_tc, n_items = 4, random = TRUE)
+# Look at the initial rankings generated
+init_small
 
 \dontrun{
   # We now give beach_init and beach_tc to compute_mallows. We tell compute_mallows

--- a/man/generate_initial_ranking.Rd
+++ b/man/generate_initial_ranking.Rd
@@ -34,7 +34,7 @@ Given a consistent set of pairwise preferences, generate a complete ranking
 of items which is consistent with the preferences.
 }
 \examples{
-# The example dataset beach_preferences contains pairwise prefences of beach.
+# The example dataset beach_preferences contains pairwise preferences of beach.
 # We must first generate the transitive closure
 beach_tc <- generate_transitive_closure(beach_preferences)
 
@@ -48,6 +48,15 @@ head(beach_init)
 # to get nicer posterior plots:
 colnames(beach_init) <- paste("Beach", seq(from = 1, to = ncol(beach_init), by = 1))
 head(beach_init)
+
+# It is also possible to pick a random sample among all topological sorts.
+# This requires first enumerating all possible sorts, and might hence be computationally
+# demanding. Here is an example, where we reduce the data considerable to speed up computation.
+small_tc <- beach_tc[beach_tc$assessor \%in\% 1:6 & beach_tc$bottom_item \%in\% 1:4 & beach_tc$top_item \%in\% 1:4, ]
+set.seed(123)
+init_small <- generate_initial_ranking(tc = small_tc, n_items = 4, random = TRUE)
+# Look at the initial rankings generated
+init_small
 
 \dontrun{
   # We now give beach_init and beach_tc to compute_mallows. We tell compute_mallows

--- a/man/generate_initial_ranking.Rd
+++ b/man/generate_initial_ranking.Rd
@@ -33,6 +33,16 @@ to \code{\link{compute_mallows}}.
 Given a consistent set of pairwise preferences, generate a complete ranking
 of items which is consistent with the preferences.
 }
+\note{
+Setting \code{random=TRUE} means that all possible orderings of each assessor's
+preferences are generated, and one of them is picked at random. This can be useful
+when experiencing convergence issues, e.g., if the MCMC algorithm does not mixed
+properly. However, finding all possible orderings is a combinatorial problem,
+which may be computationally very hard. The result may not even be possible to fit in
+memory, which may cause the R session to crash. When using this option,
+please try to increase the size of the problem incrementally, by starting with smaller
+subsets of the complete data. An example is given below.
+}
 \examples{
 # The example dataset beach_preferences contains pairwise preferences of beach.
 # We must first generate the transitive closure

--- a/man/generate_initial_ranking.Rd
+++ b/man/generate_initial_ranking.Rd
@@ -7,7 +7,8 @@
 generate_initial_ranking(
   tc,
   n_items = max(tc[, c("bottom_item", "top_item")]),
-  cl = NULL
+  cl = NULL,
+  random = FALSE
 )
 }
 \arguments{
@@ -20,6 +21,9 @@ equal the largest item index found in \code{tc}, i.e.,
 
 \item{cl}{Optional computing cluster used for parallelization, returned
 from \code{parallel::makeCluster}. Defaults to \code{NULL}.}
+
+\item{random}{Logical specifying whether or not to use a random initial ranking.
+Defaults to \code{FALSE}.}
 }
 \value{
 A matrix of rankings which can be given in the \code{rankings} argument

--- a/tests/testthat/test_generate_ranking.R
+++ b/tests/testthat/test_generate_ranking.R
@@ -23,3 +23,21 @@ test_that("generate_initial_ranking works",{
 }
 )
 
+test_that("generate_initial_ranking with random works",{
+  beach_tc <- generate_transitive_closure(beach_preferences)
+
+  small_tc <- beach_tc[beach_tc$assessor %in% 1:6 & beach_tc$bottom_item %in% 1:4 & beach_tc$top_item %in% 1:4, ]
+  set.seed(123)
+  init_small <- generate_initial_ranking(tc = small_tc, n_items = 4, random = TRUE)
+  expect_equal(init_small, structure(c(3, 1, 1, 1, 4, 3, 1, 4, 3, 4, 2, 1, 4, 3, 2, 3, 3,
+                                       4, 2, 2, 4, 2, 1, 2), .Dim = c(6L, 4L)))
+
+  set.seed(321)
+  init_small <- generate_initial_ranking(tc = small_tc, n_items = 4, random = TRUE)
+  expect_equal(init_small, structure(c(3, 1, 1, 3, 4, 3, 1, 4, 3, 4, 1, 1, 2, 2, 2, 2, 3,
+                                       4, 4, 3, 4, 1, 2, 2), .Dim = c(6L, 4L)))
+
+  expect_error(generate_initial_ranking(pair_comp, random = TRUE))
+}
+)
+


### PR DESCRIPTION
First attempt at having an option for random initial ranking. It is based on translating the C++ code at https://www.geeksforgeeks.org/all-topological-sorts-of-a-directed-acyclic-graph/ to R. 

One caveat is that enumerating all possible sorts explodes combinatorially when there are many degrees of freedom, so this one should be used with care. I have hence kept the default to `random=FALSE`.

Closes #62 .

Here is the updated example in `help("generate_initial_ranking")`, where I have added some lines with random initial rankings.

```r
# The example dataset beach_preferences contains pairwise preferences of beach.
# We must first generate the transitive closure
beach_tc <- generate_transitive_closure(beach_preferences)

# Next, we generate an initial ranking
beach_init <- generate_initial_ranking(beach_tc)

# Look at the first few rows:
head(beach_init)

# We can add more informative column names in order
# to get nicer posterior plots:
colnames(beach_init) <- paste("Beach", seq(from = 1, to = ncol(beach_init), by = 1))
head(beach_init)

# It is also possible to pick a random sample among all topological sorts.
# This requires first enumerating all possible sorts, and might hence be computationally
# demanding. Here is an example, where we reduce the data considerable to speed up computation.
small_tc <- beach_tc[beach_tc$assessor %in% 1:6 & beach_tc$bottom_item %in% 1:4 & beach_tc$top_item %in% 1:4, ]
set.seed(123)
init_small <- generate_initial_ranking(tc = small_tc, n_items = 4, random = TRUE)
# Look at the initial rankings generated
init_small
```