### PR TITLE
Rand init

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BayesMallows
 Type: Package
 Title: Bayesian Preference Learning with the Mallows Rank Model
-Version: 1.0.1
+Version: 1.0.1.9000
 Authors@R: c(person("Oystein", "Sorensen", 
                     email = "oystein.sorensen.1985@gmail.com", 
                     role = c("aut", "cre"),

--- a/R/all_topological_sorts.R
+++ b/R/all_topological_sorts.R
@@ -1,0 +1,22 @@
+# Translation to R of C++ and Python code found here
+# https://www.geeksforgeeks.org/all-topological-sorts-of-a-directed-acyclic-graph/
+all_topological_sorts <- function(graph, path, discovered, n_items){
+  flag <- FALSE
+
+  for(i in seq_len(n_items)){
+    if(attr(graph, "indegree")[[i]] == 0 && !discovered[[i]]){
+      attr(graph, "indegree")[graph[[i]]] <- attr(graph, "indegree")[graph[[i]]] - 1
+
+      path <- c(path, i)
+      discovered[[i]] <- TRUE
+      all_topological_sorts(graph, path, discovered, n_items)
+
+      attr(graph, "indegree")[graph[[i]]] <- attr(graph, "indegree")[graph[[i]]] + 1
+      path <- path[-length(path)]
+      discovered[[i]] <- FALSE
+
+      flag <- TRUE
+    }
+  }
+  if(length(path) == n_items) print(path)
+}

--- a/R/generate_initial_ranking.R
+++ b/R/generate_initial_ranking.R
@@ -20,6 +20,15 @@
 #' @return A matrix of rankings which can be given in the \code{rankings} argument
 #' to \code{\link{compute_mallows}}.
 #'
+#' @note Setting \code{random=TRUE} means that all possible orderings of each assessor's
+#' preferences are generated, and one of them is picked at random. This can be useful
+#' when experiencing convergence issues, e.g., if the MCMC algorithm does not mixed
+#' properly. However, finding all possible orderings is a combinatorial problem,
+#' which may be computationally very hard. The result may not even be possible to fit in
+#' memory, which may cause the R session to crash. When using this option,
+#' please try to increase the size of the problem incrementally, by starting with smaller
+#' subsets of the complete data. An example is given below.
+#'
 #' @export
 #'
 #' @example /inst/examples/generate_initial_ranking_example.R

--- a/R/generate_initial_ranking.R
+++ b/R/generate_initial_ranking.R
@@ -13,6 +13,9 @@
 #' @param cl Optional computing cluster used for parallelization, returned
 #' from \code{parallel::makeCluster}. Defaults to \code{NULL}.
 #'
+#' @param random Logical specifying whether or not to use a random initial ranking.
+#'   Defaults to \code{FALSE}.
+#'
 #'
 #' @return A matrix of rankings which can be given in the \code{rankings} argument
 #' to \code{\link{compute_mallows}}.
@@ -23,7 +26,7 @@
 #'
 generate_initial_ranking <- function(tc,
                                      n_items = max(tc[, c("bottom_item", "top_item")]),
-                                     cl = NULL){
+                                     cl = NULL, random = FALSE){
 
 
   if(!("BayesMallowsTC" %in% class(tc))){
@@ -44,7 +47,7 @@ generate_initial_ranking <- function(tc,
 
 create_ranks <- function(mat, n_items){
   g <- igraph::graph_from_edgelist(mat)
-  g <- as.integer(igraph::topological.sort(g))
+  g <- as.integer(igraph::topo_sort(g))
 
   # Add unranked elements at the end
   all_items <- seq(from = 1, to = n_items, by = 1)

--- a/R/generate_initial_ranking.R
+++ b/R/generate_initial_ranking.R
@@ -4,30 +4,63 @@
 #' of items which is consistent with the preferences.
 #'
 #' @param tc A dataframe with pairwise comparisons of \code{S3} subclass
-#' \code{BayesMallowsTC}, returned from \code{\link{generate_transitive_closure}}.
+#'   \code{BayesMallowsTC}, returned from
+#'   \code{\link{generate_transitive_closure}}.
 #'
 #' @param n_items The total number of items. If not provided, it is assumed to
-#'   equal the largest item index found in \code{tc}, i.e.,
-#'   \code{max(tc[, c("bottom_item", "top_item")])}.
+#'   equal the largest item index found in \code{tc}, i.e., \code{max(tc[,
+#'   c("bottom_item", "top_item")])}.
 #'
-#' @param cl Optional computing cluster used for parallelization, returned
-#' from \code{parallel::makeCluster}. Defaults to \code{NULL}.
+#' @param cl Optional computing cluster used for parallelization, returned from
+#'   \code{parallel::makeCluster}. Defaults to \code{NULL}.
 #'
-#' @param random Logical specifying whether or not to use a random initial ranking.
-#'   Defaults to \code{FALSE}.
+#' @param shuffle_unranked Logical specifying whether or not to randomly
+#'   permuted unranked items in the intial ranking. When
+#'   \code{shuffle_unranked=TRUE} and \code{random=FALSE}, all unranked items
+#'   for each assessor are randomly permuted. Otherwise, the first ordering
+#'   returned by \code{igraph::topo_sort()} is returned.
+#'
+#' @param random Logical specifying whether or not to use a random initial
+#'   ranking. Defaults to \code{FALSE}. Setting this to \code{TRUE} means that
+#'   all possible orderings consistent with the stated pairwise preferences are
+#'   generated for each assessor, and one of them is picked at random.
+#'
+#' @param random_limit Integer specifying the maximum number of items allowed
+#'   when all possible orderings are computed, i.e., when \code{random=TRUE}.
+#'   Defaults to \code{8L}.
 #'
 #'
-#' @return A matrix of rankings which can be given in the \code{rankings} argument
-#' to \code{\link{compute_mallows}}.
+#' @return A matrix of rankings which can be given in the \code{rankings}
+#'   argument to \code{\link{compute_mallows}}.
 #'
-#' @note Setting \code{random=TRUE} means that all possible orderings of each assessor's
-#' preferences are generated, and one of them is picked at random. This can be useful
-#' when experiencing convergence issues, e.g., if the MCMC algorithm does not mixed
-#' properly. However, finding all possible orderings is a combinatorial problem,
-#' which may be computationally very hard. The result may not even be possible to fit in
-#' memory, which may cause the R session to crash. When using this option,
-#' please try to increase the size of the problem incrementally, by starting with smaller
-#' subsets of the complete data. An example is given below.
+#' @note Setting \code{random=TRUE} means that all possible orderings of each
+#'   assessor's preferences are generated, and one of them is picked at random.
+#'   This can be useful when experiencing convergence issues, e.g., if the MCMC
+#'   algorithm does not mixed properly. However, finding all possible orderings
+#'   is a combinatorial problem, which may be computationally very hard. The
+#'   result may not even be possible to fit in memory, which may cause the R
+#'   session to crash. When using this option, please try to increase the size
+#'   of the problem incrementally, by starting with smaller subsets of the
+#'   complete data. An example is given below.
+#'
+#'   As detailed in the documentation to \code{\link{generate_transitive_closure}},
+#'   it is assumed that the items are labeled starting from 1. For example, if a single
+#'   comparison of the following form is provided, it is assumed that there is a total
+#'   of 30 items (\code{n_items=30}), and the initial ranking is a permutation of these 30
+#'   items consistent with the preference 29<30.
+#'
+#' \tabular{rrr}{
+#' \strong{assessor} \tab \strong{bottom_item} \tab \strong{top_item}\cr
+#' 1 \tab 29 \tab 30\cr
+#' }
+#'
+#' If in reality there are only two items, they should be relabeled to 1 and 2, as follows:
+#'
+#' \tabular{rrr}{
+#' \strong{assessor} \tab \strong{bottom_item} \tab \strong{top_item}\cr
+#' 1 \tab 1 \tab 2\cr
+#' }
+#'
 #'
 #' @export
 #'
@@ -35,7 +68,8 @@
 #'
 generate_initial_ranking <- function(tc,
                                      n_items = max(tc[, c("bottom_item", "top_item")]),
-                                     cl = NULL, random = FALSE){
+                                     cl = NULL, shuffle_unranked = FALSE, random = FALSE,
+                                     random_limit = 8L){
 
 
   if(!("BayesMallowsTC" %in% class(tc))){
@@ -43,31 +77,55 @@ generate_initial_ranking <- function(tc,
   }
   stopifnot(is.null(cl) || inherits(cl, "cluster"))
 
+  if(n_items > random_limit && random){
+    stop(paste("Number of items exceeds the limit for generation of random permutations,\n",
+               "modify the random_limit argument to override this.\n"))
+  }
+
+  if(n_items < max(tc[, c("bottom_item", "top_item")])){
+    stop("Too few items specified. Please see documentation Note about labeling of items.\n")
+  }
+
   prefs <- split(tc[, c("bottom_item", "top_item"), drop = FALSE], tc$assessor)
   if(is.null(cl)){
-    prefs <- lapply(prefs, function(x, y, r) create_ranks(as.matrix(x), y, r), n_items, random)
+    prefs <- lapply(prefs, function(x, y, sr, r) create_ranks(as.matrix(x), y, sr, r),
+                    n_items, shuffle_unranked, random)
   } else {
     prefs <- parallel::parLapply(cl = cl, X = prefs,
-                                 fun = function(x, y, r) create_ranks(as.matrix(x), y, r), n_items, random)
+                                 fun = function(x, y, sr, r) create_ranks(as.matrix(x), y, sr, r),
+                                 n_items, shuffle_unranked, random)
   }
 
   do.call(rbind, prefs)
 }
 
-create_ranks <- function(mat, n_items, random){
+create_ranks <- function(mat, n_items, shuffle_unranked, random){
 
   if(!random){
     g <- igraph::graph_from_edgelist(mat)
     g <- as.integer(igraph::topo_sort(g))
 
-    # Add unranked elements at the end
     all_items <- seq(from = 1, to = n_items, by = 1)
-    g <- c(g, setdiff(all_items, g))
+
+    if(!shuffle_unranked){
+      # Add unranked elements outside of the range at the end
+      g_final <- c(g, setdiff(all_items, g))
+
+    } else {
+      ranked_items <- unique(c(mat))
+      unranked_items <- setdiff(all_items, ranked_items)
+      # Indices of ranked elements in final vector
+      idx_ranked <- sort(sample(length(all_items), length(ranked_items)))
+      g_final <- rep(NA, n_items)
+      g_final[idx_ranked] <- g[g %in% ranked_items]
+      g_final[is.na(g_final)] <- unranked_items[sample(length(unranked_items))]
+
+    }
 
     # Convert from ordering to ranking
-    r <- create_ranking(rev(g))
+    r <- create_ranking(rev(g_final))
     mat <- matrix(r, nrow = 1)
-  } else {
+  } else{
     graph <- list()
     for(i in seq_len(n_items)){
       graph[[i]] <- unique(mat[mat[, "top_item"] == i, "bottom_item"])
@@ -87,7 +145,8 @@ create_ranks <- function(mat, n_items, random){
     sink()
     close(con)
 
-    res <- gsub("\\[1\\] ", "", stdout[sample(length(stdout), 1)])
+    res <- gsub("\\[1\\] ", "", stdout)
+    res <- res[sample(length(stdout), 1)]
 
     mat <- matrix(as.numeric(strsplit(res, split = "[^0-9]+")[[1]]), nrow = 1)
   }

--- a/inst/examples/generate_initial_ranking_example.R
+++ b/inst/examples/generate_initial_ranking_example.R
@@ -13,6 +13,14 @@ head(beach_init)
 colnames(beach_init) <- paste("Beach", seq(from = 1, to = ncol(beach_init), by = 1))
 head(beach_init)
 
+# By default, the algorithm for generating the initial ranking is deterministic.
+# It is possible to randomly permuted the unranked items with the argument shuffle_unranked,
+# as demonstrated below. This algorithm is computationally efficient, but defaults to FALSE
+# for backward compatibility.
+set.seed(2233)
+beach_init <- generate_initial_ranking(beach_tc, shuffle_unranked = TRUE)
+head(beach_init)
+
 # It is also possible to pick a random sample among all topological sorts.
 # This requires first enumerating all possible sorts, and might hence be computationally
 # demanding. Here is an example, where we reduce the data considerable to speed up computation.
@@ -21,6 +29,23 @@ set.seed(123)
 init_small <- generate_initial_ranking(tc = small_tc, n_items = 4, random = TRUE)
 # Look at the initial rankings generated
 init_small
+
+# For this small dataset, we can also study the effect of setting shuffle_unranked=TRUE
+# in more detail. We consider assessors 1 and 2 only.
+# First is the deterministic ordering. This one is equal for each run.
+generate_initial_ranking(tc = small_tc[small_tc$assessor %in% c(1, 2), ],
+                         n_items = 4, shuffle_unranked = FALSE, random = FALSE)
+# Next we shuffle the unranked, setting the seed for reproducibility.
+# For assessor 1, item 2 is unranked, and by rerunning the code multiple times,
+# we see that element (1, 2) indeed changes ranking randomly.
+# For assessor 2, item 3 is unranked, and we can also see that this item changes
+# ranking randomly when rerunning the function multiple times.
+# The ranked items also change their ranking from one random realiziation to another,
+# but their relative ordering is constant.
+set.seed(123)
+generate_initial_ranking(tc = small_tc[small_tc$assessor %in% c(1, 2), ],
+                         n_items = 4, shuffle_unranked = TRUE, random = FALSE)
+
 
 \dontrun{
   # We now give beach_init and beach_tc to compute_mallows. We tell compute_mallows

--- a/inst/examples/generate_initial_ranking_example.R
+++ b/inst/examples/generate_initial_ranking_example.R
@@ -1,4 +1,4 @@
-# The example dataset beach_preferences contains pairwise prefences of beach.
+# The example dataset beach_preferences contains pairwise preferences of beach.
 # We must first generate the transitive closure
 beach_tc <- generate_transitive_closure(beach_preferences)
 
@@ -12,6 +12,15 @@ head(beach_init)
 # to get nicer posterior plots:
 colnames(beach_init) <- paste("Beach", seq(from = 1, to = ncol(beach_init), by = 1))
 head(beach_init)
+
+# It is also possible to pick a random sample among all topological sorts.
+# This requires first enumerating all possible sorts, and might hence be computationally
+# demanding. Here is an example, where we reduce the data considerable to speed up computation.
+small_tc <- beach_tc[beach_tc$assessor %in% 1:6 & beach_tc$bottom_item %in% 1:4 & beach_tc$top_item %in% 1:4, ]
+set.seed(123)
+init_small <- generate_initial_ranking(tc = small_tc, n_items = 4, random = TRUE)
+# Look at the initial rankings generated
+init_small
 
 \dontrun{
   # We now give beach_init and beach_tc to compute_mallows. We tell compute_mallows

--- a/man/generate_initial_ranking.Rd
+++ b/man/generate_initial_ranking.Rd
@@ -34,7 +34,7 @@ Given a consistent set of pairwise preferences, generate a complete ranking
 of items which is consistent with the preferences.
 }
 \examples{
-# The example dataset beach_preferences contains pairwise prefences of beach.
+# The example dataset beach_preferences contains pairwise preferences of beach.
 # We must first generate the transitive closure
 beach_tc <- generate_transitive_closure(beach_preferences)
 
@@ -48,6 +48,15 @@ head(beach_init)
 # to get nicer posterior plots:
 colnames(beach_init) <- paste("Beach", seq(from = 1, to = ncol(beach_init), by = 1))
 head(beach_init)
+
+# It is also possible to pick a random sample among all topological sorts.
+# This requires first enumerating all possible sorts, and might hence be computationally
+# demanding. Here is an example, where we reduce the data considerable to speed up computation.
+small_tc <- beach_tc[beach_tc$assessor \%in\% 1:6 & beach_tc$bottom_item \%in\% 1:4 & beach_tc$top_item \%in\% 1:4, ]
+set.seed(123)
+init_small <- generate_initial_ranking(tc = small_tc, n_items = 4, random = TRUE)
+# Look at the initial rankings generated
+init_small
 
 \dontrun{
   # We now give beach_init and beach_tc to compute_mallows. We tell compute_mallows

--- a/man/generate_initial_ranking.Rd
+++ b/man/generate_initial_ranking.Rd
@@ -33,6 +33,16 @@ to \code{\link{compute_mallows}}.
 Given a consistent set of pairwise preferences, generate a complete ranking
 of items which is consistent with the preferences.
 }
+\note{
+Setting \code{random=TRUE} means that all possible orderings of each assessor's
+preferences are generated, and one of them is picked at random. This can be useful
+when experiencing convergence issues, e.g., if the MCMC algorithm does not mixed
+properly. However, finding all possible orderings is a combinatorial problem,
+which may be computationally very hard. The result may not even be possible to fit in
+memory, which may cause the R session to crash. When using this option,
+please try to increase the size of the problem incrementally, by starting with smaller
+subsets of the complete data. An example is given below.
+}
 \examples{
 # The example dataset beach_preferences contains pairwise preferences of beach.
 # We must first generate the transitive closure

--- a/man/generate_initial_ranking.Rd
+++ b/man/generate_initial_ranking.Rd
@@ -7,7 +7,8 @@
 generate_initial_ranking(
   tc,
   n_items = max(tc[, c("bottom_item", "top_item")]),
-  cl = NULL
+  cl = NULL,
+  random = FALSE
 )
 }
 \arguments{
@@ -20,6 +21,9 @@ equal the largest item index found in \code{tc}, i.e.,
 
 \item{cl}{Optional computing cluster used for parallelization, returned
 from \code{parallel::makeCluster}. Defaults to \code{NULL}.}
+
+\item{random}{Logical specifying whether or not to use a random initial ranking.
+Defaults to \code{FALSE}.}
 }
 \value{
 A matrix of rankings which can be given in the \code{rankings} argument

--- a/man/generate_initial_ranking.Rd
+++ b/man/generate_initial_ranking.Rd
@@ -8,40 +8,74 @@ generate_initial_ranking(
   tc,
   n_items = max(tc[, c("bottom_item", "top_item")]),
   cl = NULL,
-  random = FALSE
+  shuffle_unranked = FALSE,
+  random = FALSE,
+  random_limit = 8L
 )
 }
 \arguments{
 \item{tc}{A dataframe with pairwise comparisons of \code{S3} subclass
-\code{BayesMallowsTC}, returned from \code{\link{generate_transitive_closure}}.}
+\code{BayesMallowsTC}, returned from
+\code{\link{generate_transitive_closure}}.}
 
 \item{n_items}{The total number of items. If not provided, it is assumed to
-equal the largest item index found in \code{tc}, i.e.,
-\code{max(tc[, c("bottom_item", "top_item")])}.}
+equal the largest item index found in \code{tc}, i.e., \code{max(tc[,
+c("bottom_item", "top_item")])}.}
 
-\item{cl}{Optional computing cluster used for parallelization, returned
-from \code{parallel::makeCluster}. Defaults to \code{NULL}.}
+\item{cl}{Optional computing cluster used for parallelization, returned from
+\code{parallel::makeCluster}. Defaults to \code{NULL}.}
 
-\item{random}{Logical specifying whether or not to use a random initial ranking.
-Defaults to \code{FALSE}.}
+\item{shuffle_unranked}{Logical specifying whether or not to randomly
+permuted unranked items in the intial ranking. When
+\code{shuffle_unranked=TRUE} and \code{random=FALSE}, all unranked items
+for each assessor are randomly permuted. Otherwise, the first ordering
+returned by \code{igraph::topo_sort()} is returned.}
+
+\item{random}{Logical specifying whether or not to use a random initial
+ranking. Defaults to \code{FALSE}. Setting this to \code{TRUE} means that
+all possible orderings consistent with the stated pairwise preferences are
+generated for each assessor, and one of them is picked at random.}
+
+\item{random_limit}{Integer specifying the maximum number of items allowed
+when all possible orderings are computed, i.e., when \code{random=TRUE}.
+Defaults to \code{8L}.}
 }
 \value{
-A matrix of rankings which can be given in the \code{rankings} argument
-to \code{\link{compute_mallows}}.
+A matrix of rankings which can be given in the \code{rankings}
+  argument to \code{\link{compute_mallows}}.
 }
 \description{
 Given a consistent set of pairwise preferences, generate a complete ranking
 of items which is consistent with the preferences.
 }
 \note{
-Setting \code{random=TRUE} means that all possible orderings of each assessor's
-preferences are generated, and one of them is picked at random. This can be useful
-when experiencing convergence issues, e.g., if the MCMC algorithm does not mixed
-properly. However, finding all possible orderings is a combinatorial problem,
-which may be computationally very hard. The result may not even be possible to fit in
-memory, which may cause the R session to crash. When using this option,
-please try to increase the size of the problem incrementally, by starting with smaller
-subsets of the complete data. An example is given below.
+Setting \code{random=TRUE} means that all possible orderings of each
+  assessor's preferences are generated, and one of them is picked at random.
+  This can be useful when experiencing convergence issues, e.g., if the MCMC
+  algorithm does not mixed properly. However, finding all possible orderings
+  is a combinatorial problem, which may be computationally very hard. The
+  result may not even be possible to fit in memory, which may cause the R
+  session to crash. When using this option, please try to increase the size
+  of the problem incrementally, by starting with smaller subsets of the
+  complete data. An example is given below.
+
+  As detailed in the documentation to \code{\link{generate_transitive_closure}},
+  it is assumed that the items are labeled starting from 1. For example, if a single
+  comparison of the following form is provided, it is assumed that there is a total
+  of 30 items (\code{n_items=30}), and the initial ranking is a permutation of these 30
+  items consistent with the preference 29<30.
+
+\tabular{rrr}{
+\strong{assessor} \tab \strong{bottom_item} \tab \strong{top_item}\cr
+1 \tab 29 \tab 30\cr
+}
+
+If in reality there are only two items, they should be relabeled to 1 and 2, as follows:
+
+\tabular{rrr}{
+\strong{assessor} \tab \strong{bottom_item} \tab \strong{top_item}\cr
+1 \tab 1 \tab 2\cr
+}
 }
 \examples{
 # The example dataset beach_preferences contains pairwise preferences of beach.
@@ -59,6 +93,14 @@ head(beach_init)
 colnames(beach_init) <- paste("Beach", seq(from = 1, to = ncol(beach_init), by = 1))
 head(beach_init)
 
+# By default, the algorithm for generating the initial ranking is deterministic.
+# It is possible to randomly permuted the unranked items with the argument shuffle_unranked,
+# as demonstrated below. This algorithm is computationally efficient, but defaults to FALSE
+# for backward compatibility.
+set.seed(2233)
+beach_init <- generate_initial_ranking(beach_tc, shuffle_unranked = TRUE)
+head(beach_init)
+
 # It is also possible to pick a random sample among all topological sorts.
 # This requires first enumerating all possible sorts, and might hence be computationally
 # demanding. Here is an example, where we reduce the data considerable to speed up computation.
@@ -67,6 +109,23 @@ set.seed(123)
 init_small <- generate_initial_ranking(tc = small_tc, n_items = 4, random = TRUE)
 # Look at the initial rankings generated
 init_small
+
+# For this small dataset, we can also study the effect of setting shuffle_unranked=TRUE
+# in more detail. We consider assessors 1 and 2 only.
+# First is the deterministic ordering. This one is equal for each run.
+generate_initial_ranking(tc = small_tc[small_tc$assessor \%in\% c(1, 2), ],
+                         n_items = 4, shuffle_unranked = FALSE, random = FALSE)
+# Next we shuffle the unranked, setting the seed for reproducibility.
+# For assessor 1, item 2 is unranked, and by rerunning the code multiple times,
+# we see that element (1, 2) indeed changes ranking randomly.
+# For assessor 2, item 3 is unranked, and we can also see that this item changes
+# ranking randomly when rerunning the function multiple times.
+# The ranked items also change their ranking from one random realiziation to another,
+# but their relative ordering is constant.
+set.seed(123)
+generate_initial_ranking(tc = small_tc[small_tc$assessor \%in\% c(1, 2), ],
+                         n_items = 4, shuffle_unranked = TRUE, random = FALSE)
+
 
 \dontrun{
   # We now give beach_init and beach_tc to compute_mallows. We tell compute_mallows

--- a/tests/testthat/test_generate_ranking.R
+++ b/tests/testthat/test_generate_ranking.R
@@ -23,3 +23,21 @@ test_that("generate_initial_ranking works",{
 }
 )
 
+test_that("generate_initial_ranking with random works",{
+  beach_tc <- generate_transitive_closure(beach_preferences)
+
+  small_tc <- beach_tc[beach_tc$assessor %in% 1:6 & beach_tc$bottom_item %in% 1:4 & beach_tc$top_item %in% 1:4, ]
+  set.seed(123)
+  init_small <- generate_initial_ranking(tc = small_tc, n_items = 4, random = TRUE)
+  expect_equal(init_small, structure(c(3, 1, 1, 1, 4, 3, 1, 4, 3, 4, 2, 1, 4, 3, 2, 3, 3,
+                                       4, 2, 2, 4, 2, 1, 2), .Dim = c(6L, 4L)))
+
+  set.seed(321)
+  init_small <- generate_initial_ranking(tc = small_tc, n_items = 4, random = TRUE)
+  expect_equal(init_small, structure(c(3, 1, 1, 3, 4, 3, 1, 4, 3, 4, 1, 1, 2, 2, 2, 2, 3,
+                                       4, 4, 3, 4, 1, 2, 2), .Dim = c(6L, 4L)))
+
+  expect_error(generate_initial_ranking(pair_comp, random = TRUE))
+}
+)
+

--- a/tests/testthat/test_generate_ranking.R
+++ b/tests/testthat/test_generate_ranking.R
@@ -14,17 +14,38 @@ pair_comp <- tribble(
 )
 
 pair_comp_tc <- generate_transitive_closure(pair_comp)
+beach_tc <- generate_transitive_closure(beach_preferences)
 
 test_that("generate_initial_ranking works",{
 
   expect_error(generate_initial_ranking(pair_comp))
   expect_is(generate_initial_ranking(pair_comp_tc), "matrix")
   expect_true(all(apply(generate_initial_ranking(pair_comp_tc), 1, BayesMallows:::validate_permutation)))
+  expect_error(generate_initial_ranking(beach_tc, n_items = 10))
 }
 )
 
+test_that("generate_initial_ranking with shuffle_unranked works",{
+
+  small_tc <- beach_tc[beach_tc$assessor %in% 1:6 & beach_tc$bottom_item %in% 1:4 & beach_tc$top_item %in% 1:4, ]
+  set.seed(123)
+  init_small <- generate_initial_ranking(tc = small_tc, n_items = 4, shuffle_unranked = TRUE)
+  expect_equal(init_small, structure(c(2L, 1L, 2L, 2L, 3L, 2L, 3L, 3L, 3L, 4L, 1L, 4L, 1L,
+                                       4L, 1L, 3L, 4L, 1L, 4L, 2L, 4L, 1L, 2L, 3L), .Dim = c(6L, 4L)))
+
+  set.seed(321)
+  init_small <- generate_initial_ranking(tc = small_tc, n_items = 4, random = TRUE)
+  expect_equal(init_small, structure(c(3, 1, 1, 3, 4, 3, 1, 4, 3, 4, 1, 1, 2, 2, 2, 2, 3,
+                                       4, 4, 3, 4, 1, 2, 2), .Dim = c(6L, 4L)))
+
+  expect_error(generate_initial_ranking(pair_comp, shuffle_unranked = TRUE))
+}
+)
+
+
+
 test_that("generate_initial_ranking with random works",{
-  beach_tc <- generate_transitive_closure(beach_preferences)
+
 
   small_tc <- beach_tc[beach_tc$assessor %in% 1:6 & beach_tc$bottom_item %in% 1:4 & beach_tc$top_item %in% 1:4, ]
   set.seed(123)
@@ -38,6 +59,10 @@ test_that("generate_initial_ranking with random works",{
                                        4, 4, 3, 4, 1, 2, 2), .Dim = c(6L, 4L)))
 
   expect_error(generate_initial_ranking(pair_comp, random = TRUE))
+
+  expect_error(generate_initial_ranking(tc = small_tc, n_items = 4, random = TRUE,
+                                        random_limit = 3))
+  expect_error(generate_initial_ranking(tc = beach_tc, random = TRUE))
 }
 )
 


### PR DESCRIPTION
Updated code for random initial ranking, after discussions with @MartaCrispino.

I have added the following arguments to `generate_initial_ranking`:

- `shuffle_unranked`: logical specifying whether to randomly permute unconstrained elements. MUCH more computationally efficient than generating all possible orderings.
- `random_limit`: integer setting the limit for the possible number of items to use in combination with `random=TRUE`. This to avoid users accidentally trying to enumerate billions and billions of permutations.

I have also added error messages and notes checking whether the user has set up the data correctly, and updated examples and unit tests.