### PR TITLE
Reduced tests which took long time

### DIFF
--- a/tests/testthat/test_compute_consensus.R
+++ b/tests/testthat/test_compute_consensus.R
@@ -1,7 +1,10 @@
 context("Testing compute_consensus")
 
-b <- compute_mallows(preferences = beach_preferences, nmc = 500, seed = 123L)
-b$burnin <- 200
+beach_small <- beach_preferences %>%
+  filter(bottom_item %in% 1:3, top_item %in% 1:3)
+
+b <- compute_mallows(preferences = beach_preferences, nmc = 100, seed = 123L)
+b$burnin <- 2
 cp <- compute_consensus(b)
 map <- compute_consensus(b, type = "MAP")
 
@@ -13,28 +16,53 @@ test_that("compute_consensus returns correct object", {
 
 test_that("compute_consensus computes correctly for rho", {
   expect_equal(cp, structure(list(ranking = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
-                                              12, 13, 14, 15), item = c("Item 9", "Item 6", "Item 3", "Item 11",
-                                                                        "Item 15", "Item 10", "Item 1", "Item 5", "Item 7", "Item 13",
-                                                                        "Item 8", "Item 4", "Item 12", "Item 14", "Item 2"), cumprob = c(0.78,
-                                                                                                                                         1, 1, 0.976666666666667, 0.87, 0.983333333333333, 1, 0.703333333333333,
-                                                                                                                                         1, 1, 0.926666666666667, 0.926666666666667, 1, 0.913333333333333,
-                                                                                                                                         1)), row.names = c(NA, -15L), class = c("tbl_df", "tbl", "data.frame"
-                                                                                                                                         )))
+                                              12, 13, 14, 15), item = c("Item 3", "Item 11", "Item 1", "Item 12",
+                                                                        "Item 7", "Item 15", "Item 14", "Item 10", "Item 4", "Item 13",
+                                                                        "Item 6", "Item 9", "Item 5", "Item 8", "Item 2"), cumprob = c(0.673469387755102,
+                                                                                                                                       0.571428571428571, 0.489795918367347, 0.448979591836735, 0.755102040816327,
+                                                                                                                                       0.214285714285714, 0.5, 0.785714285714286, 0.683673469387755,
+                                                                                                                                       0.540816326530612, 0.683673469387755, 0.683673469387755, 0.73469387755102,
+                                                                                                                                       0.704081632653061, 1)), row.names = c(NA, -15L), class = c("tbl_df",
+                                                                                                                                                                                                  "tbl", "data.frame"))
+  )
 
-  expect_equal(map, structure(list(probability = c(0.34, 0.34, 0.34, 0.34, 0.34,
-                                                   0.34, 0.34, 0.34, 0.34, 0.34, 0.34, 0.34, 0.34, 0.34, 0.34),
-                                   item = c("Item 9", "Item 6", "Item 3", "Item 11", "Item 15",
-                                            "Item 10", "Item 1", "Item 5", "Item 7", "Item 13", "Item 8",
-                                            "Item 4", "Item 12", "Item 14", "Item 2"), map_ranking = c(1,
-                                                                                                       2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)), row.names = c(NA,
-                                                                                                                                                                       -15L), class = c("tbl_df", "tbl", "data.frame")))
-
-
+  expect_equal(map,
+               structure(list(probability = c(0.0510204081632653, 0.0510204081632653,
+                                              0.0510204081632653, 0.0510204081632653, 0.0510204081632653, 0.0510204081632653,
+                                              0.0510204081632653, 0.0510204081632653, 0.0510204081632653, 0.0510204081632653,
+                                              0.0510204081632653, 0.0510204081632653, 0.0510204081632653, 0.0510204081632653,
+                                              0.0510204081632653, 0.0510204081632653, 0.0510204081632653, 0.0510204081632653,
+                                              0.0510204081632653, 0.0510204081632653, 0.0510204081632653, 0.0510204081632653,
+                                              0.0510204081632653, 0.0510204081632653, 0.0510204081632653, 0.0510204081632653,
+                                              0.0510204081632653, 0.0510204081632653, 0.0510204081632653, 0.0510204081632653,
+                                              0.0510204081632653, 0.0510204081632653, 0.0510204081632653, 0.0510204081632653,
+                                              0.0510204081632653, 0.0510204081632653, 0.0510204081632653, 0.0510204081632653,
+                                              0.0510204081632653, 0.0510204081632653, 0.0510204081632653, 0.0510204081632653,
+                                              0.0510204081632653, 0.0510204081632653, 0.0510204081632653, 0.0510204081632653,
+                                              0.0510204081632653, 0.0510204081632653, 0.0510204081632653, 0.0510204081632653,
+                                              0.0510204081632653, 0.0510204081632653, 0.0510204081632653, 0.0510204081632653,
+                                              0.0510204081632653, 0.0510204081632653, 0.0510204081632653, 0.0510204081632653,
+                                              0.0510204081632653, 0.0510204081632653), item = c("Item 1", "Item 3",
+                                                                                                "Item 3", "Item 3", "Item 3", "Item 11", "Item 11", "Item 11",
+                                                                                                "Item 11", "Item 1", "Item 12", "Item 7", "Item 10", "Item 7",
+                                                                                                "Item 1", "Item 12", "Item 7", "Item 12", "Item 7", "Item 15",
+                                                                                                "Item 12", "Item 15", "Item 14", "Item 1", "Item 15", "Item 14",
+                                                                                                "Item 15", "Item 14", "Item 9", "Item 10", "Item 4", "Item 10",
+                                                                                                "Item 13", "Item 4", "Item 10", "Item 4", "Item 14", "Item 6",
+                                                                                                "Item 13", "Item 6", "Item 4", "Item 13", "Item 8", "Item 13",
+                                                                                                "Item 6", "Item 9", "Item 6", "Item 9", "Item 5", "Item 8", "Item 5",
+                                                                                                "Item 8", "Item 2", "Item 5", "Item 9", "Item 5", "Item 8", "Item 2",
+                                                                                                "Item 2", "Item 2"), map_ranking = c(1, 1, 1, 1, 2, 2, 2, 2,
+                                                                                                                                     3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8,
+                                                                                                                                     8, 8, 8, 9, 9, 9, 9, 10, 10, 10, 10, 11, 11, 11, 11, 12, 12,
+                                                                                                                                     12, 12, 13, 13, 13, 13, 14, 14, 14, 14, 15, 15, 15, 15)), row.names = c(NA,
+                                                                                                                                                                                                             -60L), class = c("tbl_df", "tbl", "data.frame"))
+  )
 })
 
 
-b2 <- compute_mallows(preferences = beach_preferences, nmc = 500, save_aug = TRUE, seed = 123L)
-b3 <- compute_mallows(preferences = beach_preferences, nmc = 500, save_aug = TRUE, aug_thinning = 3, seed = 123L)
+b2 <- compute_mallows(preferences = beach_small, nmc = 500, save_aug = TRUE, seed = 123L)
+b3 <- compute_mallows(preferences = beach_small, nmc = 500, save_aug = TRUE, aug_thinning = 3, seed = 123L)
 
 test_that("compute_consensus fails when it should", {
   # Burnin not set
@@ -53,129 +81,64 @@ test_that("compute_consensus fails when it should", {
 
 test_that("compute_consensus computes augmented ranks correctly", {
   res <- compute_consensus(b2, type = "CP", burnin = 200, parameter = "Rtilde", assessors = 1L)
-  expect_equal(res, structure(list(ranking = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
-                                               12, 13, 14, 15), item = c("Item 6", "Item 11", "Item 3", "Item 9",
-                                                                         "Item 10", "Item 15", "Item 1", "Item 12", "Item 7", "Item 13",
-                                                                         "Item 5", "Item 4", "Item 8", "Item 14", "Item 2"), cumprob = c(0.52,
-                                                                                                                                         0.903333333333333, 0.696666666666667, 0.46, 0.683333333333333,
-                                                                                                                                         0.623333333333333, 0.666666666666667, 0.76, 0.67, 0.583333333333333,
-                                                                                                                                         0.433333333333333, 0.53, 0.76, 0.626666666666667, 1)), row.names = c(NA,
-                                                                                                                                                                                                              -15L), class = c("tbl_df", "tbl", "data.frame")))
-
+  expect_equal(res, structure(list(ranking = c(1, 2, 3), item = c("Item 1", "Item 3",
+                                                                  "Item 2"), cumprob = c(0.62, 1, 1)), row.names = c(NA, -3L), class = c("tbl_df",
+                                                                                                                                         "tbl", "data.frame"))
+  )
 
   res <- compute_consensus(b3, type = "CP", burnin = 200, parameter = "Rtilde", assessors = 1L)
-  expect_equal(res, structure(list(ranking = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
-                                               12, 13, 14, 15), item = c("Item 6", "Item 11", "Item 3", "Item 9",
-                                                                         "Item 10", "Item 15", "Item 1", "Item 12", "Item 7", "Item 13",
-                                                                         "Item 5", "Item 4", "Item 8", "Item 14", "Item 2"), cumprob = c(0.52,
-                                                                                                                                         0.91, 0.7, 0.46, 0.69, 0.63, 0.67, 0.75, 0.67, 0.58, 0.44, 0.54,
-                                                                                                                                         0.74, 0.62, 1)), row.names = c(NA, -15L), class = c("tbl_df",
-                                                                                                                                                                                             "tbl", "data.frame")))
-
-
-
+  expect_equal(res, structure(list(ranking = c(1, 2, 3), item = c("Item 1", "Item 3",
+                                                                  "Item 2"), cumprob = c(0.61, 1, 1)), row.names = c(NA, -3L), class = c("tbl_df",
+                                                                                                                                         "tbl", "data.frame"))
+  )
   res <- compute_consensus(b2, type = "CP", burnin = 200, parameter = "Rtilde", assessors = c(3L, 5L))
-  expect_equal(res, structure(list(assessor = c("3", "3", "3", "3", "3", "3", "3",
-                                                "3", "3", "3", "3", "3", "3", "3", "3", "5", "5", "5", "5", "5",
-                                                "5", "5", "5", "5", "5", "5", "5", "5", "5", "5"), ranking = c(1,
-                                                                                                               2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 1, 2, 3, 4, 5,
-                                                                                                               6, 7, 8, 9, 10, 11, 12, 13, 14, 15), item = c("Item 9", "Item 6",
-                                                                                                                                                             "Item 15", "Item 1", "Item 3", "Item 11", "Item 10", "Item 7",
-                                                                                                                                                             "Item 13", "Item 14", "Item 8", "Item 5", "Item 2", "Item 12",
-                                                                                                                                                             "Item 4", "Item 9", "Item 6", "Item 10", "Item 11", "Item 5",
-                                                                                                                                                             "Item 4", "Item 3", "Item 14", "Item 15", "Item 1", "Item 7",
-                                                                                                                                                             "Item 8", "Item 2", "Item 12", "Item 13"), cumprob = c(1, 0.916666666666667,
-                                                                                                                                                                                                                    0.733333333333333, 0.363333333333333, 0.506666666666667, 0.57,
-                                                                                                                                                                                                                    0.65, 0.513333333333333, 0.69, 0.6, 0.586666666666667, 0.77,
-                                                                                                                                                                                                                    0.64, 0.67, 1, 0.39, 0.783333333333333, 0.786666666666667, 0.703333333333333,
-                                                                                                                                                                                                                    0.76, 0.73, 0.57, 0.326666666666667, 0.486666666666667, 0.68,
-                                                                                                                                                                                                                    0.78, 0.853333333333333, 0.596666666666667, 0.833333333333333,
-                                                                                                                                                                                                                    1)), row.names = c(NA, -30L), class = c("tbl_df", "tbl", "data.frame"
-                                                                                                                                                                                                                    )))
 
+  expect_equal(res, structure(list(assessor = c("3", "3", "3", "5", "5", "5"), ranking = c(1,
+                                                                                           2, 3, 1, 2, 3), item = c("Item 1", "Item 3", "Item 2", "Item 1",
+                                                                                                                    "Item 3", "Item 2"), cumprob = c(0.696666666666667, 0.836666666666667,
+                                                                                                                                                     1, 1, 1, 1)), row.names = c(NA, -6L), class = c("tbl_df", "tbl",
+                                                                                                                                                                                                     "data.frame"))
+  )
 
   res <- compute_consensus(b3, type = "CP", burnin = 200, parameter = "Rtilde", assessors = c(3L, 5L))
-  expect_equal(res, structure(list(assessor = c("3", "3", "3", "3", "3", "3", "3",
-                                                "3", "3", "3", "3", "3", "3", "3", "3", "5", "5", "5", "5", "5",
-                                                "5", "5", "5", "5", "5", "5", "5", "5", "5", "5"), ranking = c(1,
-                                                                                                               2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 1, 2, 3, 4, 5,
-                                                                                                               6, 7, 8, 9, 10, 11, 12, 13, 14, 15), item = c("Item 9", "Item 6",
-                                                                                                                                                             "Item 15", "Item 1", "Item 3", "Item 11", "Item 10", "Item 7",
-                                                                                                                                                             "Item 13", "Item 14", "Item 8", "Item 5", "Item 2", "Item 12",
-                                                                                                                                                             "Item 4", "Item 9", "Item 6", "Item 10", "Item 11", "Item 5",
-                                                                                                                                                             "Item 4", "Item 3", "Item 14", "Item 15", "Item 1", "Item 7",
-                                                                                                                                                             "Item 8", "Item 2", "Item 12", "Item 13"), cumprob = c(1, 0.92,
-                                                                                                                                                                                                                    0.75, 0.36, 0.52, 0.56, 0.64, 0.52, 0.7, 0.61, 0.57, 0.78, 0.64,
-                                                                                                                                                                                                                    0.68, 1, 0.38, 0.79, 0.78, 0.71, 0.75, 0.73, 0.57, 0.33, 0.48,
-                                                                                                                                                                                                                    0.66, 0.78, 0.85, 0.6, 0.84, 1)), row.names = c(NA, -30L), class = c("tbl_df",
-                                                                                                                                                                                                                                                                                         "tbl", "data.frame")))
-
-
+  expect_equal(res,
+               structure(list(assessor = c("3", "3", "3", "5", "5", "5"), ranking = c(1,
+                                                                                      2, 3, 1, 2, 3), item = c("Item 1", "Item 3", "Item 2", "Item 1",
+                                                                                                               "Item 3", "Item 2"), cumprob = c(0.69, 0.84, 1, 1, 1, 1)), row.names = c(NA,
+                                                                                                                                                                                        -6L), class = c("tbl_df", "tbl", "data.frame"))
+  )
 
   res <- compute_consensus(b2, type = "MAP", burnin = 200, parameter = "Rtilde", assessors = 1L)
-  expect_equal(res, structure(list(probability = c(0.0433333333333333, 0.0433333333333333,
-                                                   0.0433333333333333, 0.0433333333333333, 0.0433333333333333, 0.0433333333333333,
-                                                   0.0433333333333333, 0.0433333333333333, 0.0433333333333333, 0.0433333333333333,
-                                                   0.0433333333333333, 0.0433333333333333, 0.0433333333333333, 0.0433333333333333,
-                                                   0.0433333333333333), item = c("Item 6", "Item 11", "Item 3",
-                                                                                 "Item 9", "Item 10", "Item 15", "Item 1", "Item 12", "Item 7",
-                                                                                 "Item 13", "Item 4", "Item 5", "Item 8", "Item 2", "Item 14"),
-                                   map_ranking = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
-                                                   14, 15)), row.names = c(NA, -15L), class = c("tbl_df", "tbl",
-                                                                                                "data.frame")))
-
+  expect_equal(res, structure(list(probability = c(0.62, 0.62, 0.62), item = c("Item 1",
+                                                                               "Item 3", "Item 2"), map_ranking = c(1, 2, 3)), row.names = c(NA,
+                                                                                                                                             -3L), class = c("tbl_df", "tbl", "data.frame"))
+  )
 
   res <- compute_consensus(b3, type = "MAP", burnin = 200, parameter = "Rtilde", assessors = 1L)
-  expect_equal(res, structure(list(probability = c(0.05, 0.05, 0.05, 0.05, 0.05,
-                                                   0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05),
-                                   item = c("Item 6", "Item 11", "Item 3", "Item 9", "Item 10",
-                                            "Item 15", "Item 1", "Item 12", "Item 7", "Item 13", "Item 4",
-                                            "Item 5", "Item 8", "Item 2", "Item 14"), map_ranking = c(1,
-                                                                                                      2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)), row.names = c(NA,
-                                                                                                                                                                      -15L), class = c("tbl_df", "tbl", "data.frame")))
-
-
+  expect_equal(res,
+               structure(list(probability = c(0.61, 0.61, 0.61), item = c("Item 1",
+                                                                          "Item 3", "Item 2"), map_ranking = c(1, 2, 3)), row.names = c(NA,
+                                                                                                                                        -3L), class = c("tbl_df", "tbl", "data.frame"))
+  )
 
   res <- compute_consensus(b2, type = "MAP", burnin = 200, parameter = "Rtilde", assessors = c(5L, 3L))
-  expect_equal(res, structure(list(assessor = c(3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-                                                3, 3, 3, 3, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5), probability = c(0.0333333333333333,
-                                                                                                                          0.0333333333333333, 0.0333333333333333, 0.0333333333333333, 0.0333333333333333,
-                                                                                                                          0.0333333333333333, 0.0333333333333333, 0.0333333333333333, 0.0333333333333333,
-                                                                                                                          0.0333333333333333, 0.0333333333333333, 0.0333333333333333, 0.0333333333333333,
-                                                                                                                          0.0333333333333333, 0.0333333333333333, 0.0266666666666667, 0.0266666666666667,
-                                                                                                                          0.0266666666666667, 0.0266666666666667, 0.0266666666666667, 0.0266666666666667,
-                                                                                                                          0.0266666666666667, 0.0266666666666667, 0.0266666666666667, 0.0266666666666667,
-                                                                                                                          0.0266666666666667, 0.0266666666666667, 0.0266666666666667, 0.0266666666666667,
-                                                                                                                          0.0266666666666667), item = c("Item 9", "Item 6", "Item 15",
-                                                                                                                                                        "Item 10", "Item 3", "Item 1", "Item 7", "Item 11", "Item 13",
-                                                                                                                                                        "Item 5", "Item 14", "Item 2", "Item 4", "Item 12", "Item 8",
-                                                                                                                                                        "Item 9", "Item 6", "Item 10", "Item 11", "Item 5", "Item 4",
-                                                                                                                                                        "Item 3", "Item 1", "Item 15", "Item 8", "Item 2", "Item 7",
-                                                                                                                                                        "Item 14", "Item 13", "Item 12"), map_ranking = c(1, 2, 3, 4,
-                                                                                                                                                                                                          5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 1, 2, 3, 4, 5, 6, 7, 8,
-                                                                                                                                                                                                          9, 10, 11, 12, 13, 14, 15)), row.names = c(NA, -30L), class = c("tbl_df",
-                                                                                                                                                                                                                                                                          "tbl", "data.frame")))
-
+  expect_equal(res, structure(list(assessor = c(3, 3, 3, 5, 5, 5), probability = c(0.533333333333333,
+                                                                                   0.533333333333333, 0.533333333333333, 1, 1, 1), item = c("Item 1",
+                                                                                                                                            "Item 3", "Item 2", "Item 1", "Item 3", "Item 2"), map_ranking = c(1,
+                                                                                                                                                                                                               2, 3, 1, 2, 3)), row.names = c(NA, -6L), class = c("tbl_df",
+                                                                                                                                                                                                                                                                  "tbl", "data.frame"))
+  )
 
   res <- compute_consensus(b3, type = "MAP", burnin = 200, parameter = "Rtilde", assessors = c(5L, 3L))
 
-  expect_equal(res, structure(list(assessor = c(3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-                                                3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 5, 5,
-                                                5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5), probability = c(0.03,
-                                                                                                        0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03,
-                                                                                                        0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03,
-                                                                                                        0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03,
-                                                                                                        0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03
-                                                ), item = c("Item 9", "Item 9", "Item 6", "Item 6", "Item 15",
-                                                            "Item 15", "Item 10", "Item 11", "Item 3", "Item 13", "Item 1",
-                                                            "Item 1", "Item 7", "Item 14", "Item 11", "Item 3", "Item 13",
-                                                            "Item 7", "Item 5", "Item 10", "Item 14", "Item 5", "Item 2",
-                                                            "Item 8", "Item 4", "Item 2", "Item 12", "Item 4", "Item 8",
-                                                            "Item 12", "Item 9", "Item 6", "Item 10", "Item 11", "Item 5",
-                                                            "Item 4", "Item 3", "Item 1", "Item 15", "Item 8", "Item 2",
-                                                            "Item 7", "Item 14", "Item 13", "Item 12"), map_ranking = c(1,
-                                                                                                                        1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11,
-                                                                                                                        11, 12, 12, 13, 13, 14, 14, 15, 15, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-                                                                                                                        10, 11, 12, 13, 14, 15)), row.names = c(NA, -45L), class = c("tbl_df",
-                                                                                                                                                                                     "tbl", "data.frame")))
+  expect_equal(res,
+               structure(list(assessor = c(3, 3, 3, 5, 5, 5), probability = c(0.53,
+                                                                              0.53, 0.53, 1, 1, 1), item = c("Item 1", "Item 3", "Item 2",
+                                                                                                             "Item 1", "Item 3", "Item 2"), map_ranking = c(1, 2, 3, 1, 2,
+                                                                                                                                                            3)), row.names = c(NA, -6L), class = c("tbl_df", "tbl", "data.frame"
+                                                                                                                                                            ))
+  )
+
+
+
     })

--- a/tests/testthat/test_compute_mallows.R
+++ b/tests/testthat/test_compute_mallows.R
@@ -73,10 +73,12 @@ test_that("compute_mallows runs with the right distances", {
 })
 
 test_that("compute_mallows handles integer preferences", {
+  set.seed(123)
   m <- beach_preferences %>%
+    filter(top_item %in% c(1, 2, 3) | bottom_item %in% c(1, 2, 3)) %>%
+    sample_n(20) %>%
     mutate_all(as.integer) %>%
-    compute_mallows(preferences = .)
-
+    compute_mallows(preferences = ., nmc = 20)
 })
 
 test_that("compute_mallows handles data with lots of missings",{
@@ -109,11 +111,14 @@ test_that("compute_mallows treats obs_freq properly",{
   expect_equal(m1, m2)
 
   # Test with repeated beach preferences
-  obs_freq <- rep(1:4, each = 15)
+  obs_freq <- c(2, 1, 4)
+
+  beach_small <- beach_preferences %>%
+    filter(assessor %in% c(1, 2, 3))
 
   # Next, we create a new hypthetical beach_preferences dataframe where each
   # assessor is replicated 1-4 times
-  beach_pref_rep <- beach_preferences %>%
+  beach_pref_rep <- beach_small %>%
     mutate(new_assessor = map(obs_freq[assessor], ~ 1:.x)) %>%
     unnest(cols = new_assessor) %>%
     mutate(assessor = paste(assessor, new_assessor, sep = ",")) %>%
@@ -125,7 +130,7 @@ test_that("compute_mallows treats obs_freq properly",{
   # We generate the initial rankings for the repeated and the "unrepeated"
   # data
   set.seed(1223)
-  beach_tc <- generate_transitive_closure(beach_preferences)
+  beach_tc <- generate_transitive_closure(beach_small)
   beach_rankings <- generate_initial_ranking(beach_tc, n_items = 15)
   beach_rankings_rep <- generate_initial_ranking(beach_tc_rep, n_items = 15)
 
@@ -136,20 +141,20 @@ test_that("compute_mallows treats obs_freq properly",{
                                        nmc = 10, seed = 3344L)
 
   expect_equal(model_fit_obs_freq$rho$value,
-               c(15, 4, 12, 13, 8, 6, 2, 14, 3, 11, 10, 1, 9, 7, 5, 15, 3, 12,
-                 13, 8, 6, 1, 14, 2, 11, 10, 4, 9, 7, 5, 15, 2, 12, 13, 8, 6,
-                 3, 14, 1, 11, 10, 4, 9, 7, 5, 15, 2, 12, 13, 8, 6, 5, 14, 1,
-                 11, 10, 3, 9, 7, 4, 15, 2, 12, 13, 8, 6, 5, 14, 1, 11, 10, 3,
-                 9, 7, 4, 15, 2, 12, 13, 8, 6, 5, 14, 1, 11, 10, 3, 9, 7, 4, 15,
-                 2, 12, 13, 9, 6, 5, 14, 1, 11, 7, 3, 10, 8, 4, 15, 2, 12, 13,
-                 8, 6, 5, 14, 1, 11, 7, 3, 10, 9, 4, 15, 2, 11, 13, 8, 6, 5, 14,
-                 1, 12, 7, 3, 10, 9, 4, 15, 2, 12, 13, 8, 6, 5, 14, 1, 9, 7, 3,
-                 11, 10, 4))
+               c(15, 4, 12, 13, 8, 6, 2, 14, 3, 11, 10, 1, 9, 7, 5, 15, 4, 12,
+                 13, 9, 6, 2, 14, 3, 8, 11, 1, 10, 7, 5, 15, 4, 12, 13, 8, 6,
+                 2, 14, 3, 9, 11, 1, 10, 7, 5, 15, 4, 12, 13, 9, 6, 2, 14, 3,
+                 8, 11, 1, 10, 7, 5, 15, 4, 12, 13, 9, 6, 2, 14, 3, 8, 11, 1,
+                 10, 7, 5, 15, 5, 12, 13, 9, 6, 2, 14, 4, 8, 11, 1, 10, 7, 3,
+                 15, 5, 12, 13, 9, 6, 2, 14, 4, 8, 10, 1, 11, 7, 3, 15, 4, 12,
+                 13, 9, 5, 2, 14, 7, 8, 10, 1, 11, 6, 3, 14, 4, 12, 13, 9, 5,
+                 2, 15, 7, 8, 10, 1, 11, 6, 3, 14, 4, 12, 13, 9, 6, 2, 15, 5,
+                 8, 10, 1, 11, 7, 3))
 
   expect_equal(model_fit_obs_freq$alpha$value,
-               c(1, 1, 1, 0.86535647165335, 0.86535647165335, 0.825179803947417,
-                 0.751782270910306, 0.751782270910306, 0.751782270910306, 0.751782270910306
-               ))
+               c(1, 1.07422639598934, 0.867111587670556, 0.870763091397458,
+                 0.814708756686028, 0.763045119115647, 0.775326303198559, 0.695442598519739,
+                 0.67554927571174, 0.600167230862289))
 
   # Next for the repeated data.
   model_fit_rep <- compute_mallows(rankings = beach_rankings_rep,
@@ -159,18 +164,18 @@ test_that("compute_mallows treats obs_freq properly",{
 
 
   expect_equal(model_fit_rep$rho$value,
-               c(15, 4, 12, 13, 8, 6, 2, 14, 3, 11, 10, 1, 9, 7, 5, 15, 4, 12,
-                 13, 8, 6, 2, 14, 3, 11, 10, 1, 9, 7, 5, 15, 4, 12, 13, 8, 6,
-                 2, 14, 3, 11, 10, 1, 9, 7, 5, 14, 4, 12, 13, 8, 6, 2, 15, 3,
-                 11, 10, 1, 9, 7, 5, 15, 4, 12, 13, 8, 6, 2, 14, 3, 11, 10, 1,
-                 9, 7, 5, 15, 4, 12, 13, 8, 6, 2, 14, 3, 11, 10, 1, 9, 7, 5, 15,
-                 4, 12, 13, 9, 6, 2, 14, 3, 11, 10, 1, 8, 7, 5, 15, 4, 12, 13,
-                 9, 6, 2, 14, 3, 11, 10, 1, 8, 7, 5, 14, 4, 12, 13, 9, 6, 2, 15,
-                 3, 11, 10, 1, 8, 7, 5, 14, 4, 12, 13, 9, 6, 2, 15, 3, 11, 10,
-                 1, 8, 7, 5))
+               c(15, 4, 12, 13, 8, 6, 2, 14, 3, 11, 10, 1, 9, 7, 5, 15, 3, 12,
+                 13, 8, 6, 4, 14, 2, 11, 10, 1, 9, 7, 5, 15, 3, 12, 13, 8, 6,
+                 4, 14, 2, 11, 10, 1, 9, 7, 5, 15, 3, 12, 13, 8, 5, 4, 14, 2,
+                 11, 10, 1, 9, 7, 6, 15, 2, 12, 13, 8, 5, 4, 14, 3, 11, 10, 1,
+                 9, 7, 6, 12, 2, 13, 14, 8, 5, 4, 15, 3, 11, 10, 1, 9, 7, 6, 11,
+                 2, 13, 14, 8, 5, 4, 15, 3, 10, 9, 1, 12, 7, 6, 12, 2, 11, 14,
+                 8, 5, 4, 15, 3, 10, 9, 1, 13, 7, 6, 12, 2, 11, 14, 9, 5, 4, 15,
+                 3, 10, 8, 1, 13, 7, 6, 12, 2, 11, 14, 9, 5, 4, 15, 3, 10, 8,
+                 1, 13, 7, 6))
 
   expect_equal(model_fit_rep$alpha$value,
-               c(1, 1, 0.903043979825357, 0.903043979825357, 0.861700605603424,
-                 0.861700605603424, 0.861700605603424, 0.742080897545894, 0.742080897545894,
-                 0.742080897545894))
+               c(1, 1.09844540139283, 0.991042262448225, 0.902332143366064,
+                 1.00941552183767, 1.05591659293716, 1.2025606578257, 1.16106661791628,
+                 1.25137708104917, 1.0752293035996))
 })

--- a/tests/testthat/test_plot_top_k.R
+++ b/tests/testthat/test_plot_top_k.R
@@ -1,7 +1,9 @@
 context("Testing plot_top_k and predict_top_k")
 
 test_that("plot_top_k and predict_top_k fail when they should", {
-  beach_tc <- generate_transitive_closure(beach_preferences)
+  beach_small <- beach_preferences %>%
+    filter(bottom_item %in% 1:5, top_item %in% 1:5)
+  beach_tc <- generate_transitive_closure(beach_small)
   beach_init_rank <- generate_initial_ranking(beach_tc)
   bmm <- compute_mallows(rankings = beach_init_rank, preferences = beach_tc,
                          nmc = 100, save_aug = TRUE)
@@ -37,27 +39,27 @@ test_that("plot_top_k and predict_top_k fail when they should", {
   pred <- predict_top_k(bmm, burnin = 90, k = 3)
   expect_equal(
     pred[c(1, 10, 90, 91, 200), ],
-    structure(list(assessor = c(1, 1, 6, 7, 14), item = c("Item 1",
-                                                          "Item 4", "Item 9", "Item 1", "Item 13"), prob = c(0, 0, 1, 0,
-                                                                                                             0)), row.names = c(NA, -5L), groups = structure(list(assessor = c(1,
-                                                                                                                                                                               6, 7, 14), .rows = structure(list(1:2, 3L, 4L, 5L), ptype = integer(0), class = c("vctrs_list_of",
-                                                                                                                                                                                                                                                                 "vctrs_vctr", "list"))), row.names = c(NA, 4L), class = c("tbl_df",
-                                                                                                                                                                                                                                                                                                                           "tbl", "data.frame"), .drop = TRUE), class = c("grouped_df",
-                                                                                                                                                                                                                                                                                                                                                                          "tbl_df", "tbl", "data.frame"))
-  )
+    structure(list(assessor = c(1, 2, 18, 19, 40), item = c("Item 1",
+                                                            "Item 5", "Item 5", "Item 1", "Item 5"), prob = c(1, 1, 1, 1,
+                                                                                                              1)), row.names = c(NA, -5L), groups = structure(list(assessor = c(1,
+                                                                                                                                                                                2, 18, 19, 40), .rows = structure(list(1L, 2L, 3L, 4L, 5L), ptype = integer(0), class = c("vctrs_list_of",
+                                                                                                                                                                                                                                                                          "vctrs_vctr", "list"))), row.names = c(NA, -5L), class = c("tbl_df",
+                                                                                                                                                                                                                                                                                                                                     "tbl", "data.frame"), .drop = TRUE), class = c("grouped_df",
+                                                                                                                                                                                                                                                                                                                                                                                    "tbl_df", "tbl", "data.frame")
+              ) )
 
 
   pred <- predict_top_k(bmm, burnin = 90, k = 5)
   expect_equal(
     head(pred),
-    structure(list(assessor = c(1, 1, 1, 1, 1, 1), item = c("Item 1",
-                                                            "Item 10", "Item 11", "Item 12", "Item 13", "Item 14"), prob = c(0,
-                                                                                                                             0.4, 1, 0.6, 0, 0)), row.names = c(NA, -6L), groups = structure(list(
-                                                                                                                               assessor = 1, .rows = structure(list(1:6), ptype = integer(0), class = c("vctrs_list_of",
-                                                                                                                                                                                                        "vctrs_vctr", "list"))), row.names = 1L, class = c("tbl_df",
-                                                                                                                                                                                                                                                           "tbl", "data.frame"), .drop = TRUE), class = c("grouped_df",
-                                                                                                                                                                                                                                                                                                          "tbl_df", "tbl", "data.frame"))
-  )
+    structure(list(assessor = c(1, 1, 1, 1, 1, 2), item = c("Item 1",
+                                                            "Item 2", "Item 3", "Item 4", "Item 5", "Item 1"), prob = c(1,
+                                                                                                                        1, 1, 1, 1, 1)), row.names = c(NA, -6L), groups = structure(list(
+                                                                                                                          assessor = c(1, 2), .rows = structure(list(1:5, 6L), ptype = integer(0), class = c("vctrs_list_of",
+                                                                                                                                                                                                             "vctrs_vctr", "list"))), row.names = c(NA, -2L), class = c("tbl_df",
+                                                                                                                                                                                                                                                                        "tbl", "data.frame"), .drop = TRUE), class = c("grouped_df",
+                                                                                                                                                                                                                                                                                                                       "tbl_df", "tbl", "data.frame")))
+
 })
 
 


### PR DESCRIPTION
Kept all the same tests but reduced the number of iterations in those that took a long time to run. This will enable us to add more tests later without getting timing issues. It's particularly important on valgrind, where tests take really long to run, so we bump into the 20-minute limit.

Here is before (i.e., master branch):

```r
> devtools::test()
i Loading BayesMallows
i Testing BayesMallows
√ |  OK F W S | Context
√ |   5       | Testing assess_convergence [0.2 s]                                                       
√ |  18       | Testing compute_consensus [6.4 s]                                                        
√ |  36       | Testing compute_mallows [7.3 s]                                                          
√ |  26       | Testing computation of distance                                                          
√ |   6       | Testing function estimate_partition_function                                             
√ |   9       | expected_dist                                                                            
√ |  12       | Testing generation of initial ranking [0.7 s]                                            
√ |   5       | lik_db_mix                                                                               
√ |   4       | Testing MCMC function on potato data [0.1 s]                                             
√ |   6       | Testing misc C++ functions                                                               
√ |   4       | Testing misc functions                                                                   
√ |  58       | Testing computation of partition functions [0.1 s]                                       
√ |   4       | Testing plot.BayesMallows                                                                
√ |   4       | Testing plot_elbow [0.2 s]                                                               
√ |  15       | Testing plot_top_k and predict_top_k [3.4 s]                                             
√ |   5       | Testing print.BayesMallows and print.BayesMallowsMixtures                                
√ |   2       | Testing that the random numbers are equal between platforms [1.1 s]                      
√ |   6       | Testing rank_conversion                                                                  
√ |   4       | rank_freq_distr                                                                          
√ |  16       | Testing sample_mallows [0.8 s]                                                           
√ |   2       | Testing functions for pairwise preferences                                               

== Results ==============================================================================================
Duration: 21.0 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 247 ]
```

Here is after (i.e., this pull request):

```r
> devtools::test()
i Loading BayesMallows
i Testing BayesMallows
√ |  OK F W S | Context
√ |   5       | Testing assess_convergence [0.2 s]                                                       
√ |  18       | Testing compute_consensus [3.1 s]                                                        
√ |  36       | Testing compute_mallows [1.2 s]                                                          
√ |  26       | Testing computation of distance                                                          
√ |   6       | Testing function estimate_partition_function                                             
√ |   9       | expected_dist                                                                            
√ |  12       | Testing generation of initial ranking [0.7 s]                                            
√ |   5       | lik_db_mix                                                                               
√ |   4       | Testing MCMC function on potato data [0.1 s]                                             
√ |   6       | Testing misc C++ functions                                                               
√ |   4       | Testing misc functions                                                                   
√ |  58       | Testing computation of partition functions [0.1 s]                                       
√ |   4       | Testing plot.BayesMallows                                                                
√ |   4       | Testing plot_elbow [0.2 s]                                                               
√ |  15       | Testing plot_top_k and predict_top_k [2.8 s]                                             
√ |   5       | Testing print.BayesMallows and print.BayesMallowsMixtures                                
√ |   2       | Testing that the random numbers are equal between platforms [1.0 s]                      
√ |   6       | Testing rank_conversion                                                                  
√ |   4       | rank_freq_distr                                                                          
√ |  16       | Testing sample_mallows [0.8 s]                                                           
√ |   2       | Testing functions for pairwise preferences                                               

== Results ==============================================================================================
Duration: 10.8 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 247 ]
```