### PR TITLE
Fix class attributions

### DIFF
--- a/R/compute_posterior_intervals.R
+++ b/R/compute_posterior_intervals.R
@@ -63,13 +63,13 @@ compute_posterior_intervals.BayesMallows <- function(
   if(parameter == "alpha" || parameter == "cluster_probs"){
 
     df <- dplyr::group_by(df, .data$cluster)
-    class(df) <- c("BayesMallows", "grouped_df", "tbl_df", "tbl", "data.frame")
+    class(df) <- c("posterior_BayesMallows", "grouped_df", "tbl_df", "tbl", "data.frame")
     df <- .compute_posterior_intervals(df, parameter, level, decimals)
 
   } else if(parameter == "rho"){
     decimals <- 0
     df <- dplyr::group_by(df, .data$cluster, .data$item)
-    class(df) <- c("BayesMallows", "grouped_df", "tbl_df", "tbl", "data.frame")
+    class(df) <- c("posterior_BayesMallows", "grouped_df", "tbl_df", "tbl", "data.frame")
     df <- .compute_posterior_intervals(df, parameter, level, decimals, discrete = TRUE)
 
   }
@@ -105,12 +105,12 @@ compute_posterior_intervals.SMCMallows <- function(
 
   if (parameter == "alpha" || parameter == "cluster_probs") {
     df <- dplyr::group_by(df, .data$cluster)
-    class(df) <- c("SMCMallows", "grouped_df", "tbl_df", "tbl", "data.frame")
+    class(df) <- c("posterior_SMCMallows", "grouped_df", "tbl_df", "tbl", "data.frame")
     df <- .compute_posterior_intervals(df, parameter, level, decimals)
   } else if (parameter == "rho") {
     decimals <- 0
     df <- dplyr::group_by(df, .data$cluster, .data$item)
-    class(df) <- c("SMCMallows", "grouped_df", "tbl_df", "tbl", "data.frame")
+    class(df) <- c("posterior_SMCMallows", "grouped_df", "tbl_df", "tbl", "data.frame")
     df <- .compute_posterior_intervals(df, parameter, level, decimals, discrete = TRUE)
   }
 
@@ -123,7 +123,7 @@ compute_posterior_intervals.SMCMallows <- function(
   return(df)
 }
 
-.compute_posterior_intervals.BayesMallows <- function(
+.compute_posterior_intervals.posterior_BayesMallows <- function(
   df, parameter, level, decimals, discrete = FALSE, ...
 ){
   dplyr::do(df, {
@@ -186,7 +186,7 @@ compute_posterior_intervals.SMCMallows <- function(
 
 # same as compute_posterior_intervals, but removed the bayesmallows object and
 # some other columns
-.compute_posterior_intervals.SMCMallows <- function(
+.compute_posterior_intervals.posterior_SMCMallows <- function(
   df, parameter, level, decimals, discrete = FALSE, ...
 ) {
   dplyr::do(df, {

--- a/tests/testthat/test-compute_consensus_workflow.R
+++ b/tests/testthat/test-compute_consensus_workflow.R
@@ -1,0 +1,120 @@
+# This script checks the correct usage of the generic functions created during
+# the fix of issue 80.
+set.seed(6998768)
+
+context("compute_posterior_interval() classes")
+
+# Typical BayesMallows workflow ================================================
+
+fit_bm <- compute_mallows(potato_visual)
+fit_bm$burnin <- 1000
+fit_bm_post_alpha <- compute_posterior_intervals(fit_bm, parameter = "alpha")
+fit_bm_post_rho <- compute_posterior_intervals(fit_bm, parameter = "rho")
+
+# Typical SMC-Mallows workflow =================================================
+
+n_items <- ncol(sushi_rankings)
+metric <- "footrule"
+alpha_vector <- seq(from = 0, to = 15, by = 0.1)
+iter <- 1e3
+degree <- 10
+logz_estimate <- estimate_partition_function(
+	method = "importance_sampling", alpha_vector = alpha_vector,
+	n_items = n_items, metric = metric, nmc = iter, degree = degree
+)
+data <- sushi_rankings[1:100, ]
+leap_size <- floor(n_items / 5)
+nmc <- N <- 1000
+Time <- 20
+fit_smc <- smc_mallows_new_users_complete(
+	R_obs = data, n_items = n_items, metric = metric, leap_size = leap_size,
+	N = N, Time = Time, logz_estimate = logz_estimate, mcmc_kernel_app = 5,
+	num_new_obs = 5, alpha_prop_sd = 0.5, lambda = 0.15, alpha_max = 1e6
+)
+fit_smc_alpha <- fit_smc$alpha_samples[, Time + 1]
+fit_smc_post_alpha <- compute_posterior_intervals_alpha(
+	output = fit_smc_alpha, nmc = nmc, burnin = 0, verbose = FALSE
+)
+fit_smc_rho <- fit_smc$rho_samples[, , Time + 1]
+fit_smc_post_rho <- compute_posterior_intervals_rho(
+	output = fit_smc_rho, nmc = nmc, burnin = 0,
+	verbose = FALSE
+)
+
+# Emulating the internal workings of compute_posterior_intervals ===============
+
+# BayesMallows ------------------------------------------- #
+
+fit_bm_alpha <- fit_bm$alpha
+fit_bm_alpha <- dplyr::group_by(fit_bm_alpha, .data$cluster)
+class(fit_bm_alpha) <- c(
+	"posterior_BayesMallows", "grouped_df", "tbl_df", "tbl", "data.frame"
+)
+fit_bm_post_internal_alpha <- .compute_posterior_intervals(
+	fit_bm_alpha, "alpha", .95, 3L
+)
+
+fit_bm_rho <- fit_bm$rho
+fit_bm_rho <- dplyr::group_by(fit_bm_rho, .data$cluster)
+class(fit_bm_rho) <- c(
+	"posterior_BayesMallows", "grouped_df", "tbl_df", "tbl", "data.frame"
+)
+fit_bm_post_internal_rho <- .compute_posterior_intervals(
+	fit_bm_rho, "rho", .95, 3L
+)
+
+# SMC-Mallows -------------------------------------------- #
+
+fit_smc_alpha <- data.frame(iteration = seq_len(nmc), value = fit_smc_alpha)
+fit_smc_alpha$n_clusters <- 1
+fit_smc_alpha$cluster <- "Cluster 1"
+fit_smc_alpha <- dplyr::group_by(fit_smc_alpha, .data$cluster)
+class(fit_smc_alpha) <- c(
+	"posterior_SMCMallows", "grouped_df", "tbl_df", "tbl", "data.frame"
+)
+fit_smc_post_internal_alpha <- .compute_posterior_intervals(
+	fit_smc_alpha, "alpha", .95, 3L
+)
+
+fit_smc_rho <- smc_processing(fit_smc_rho)
+fit_smc_rho$n_clusters <- 1
+fit_smc_rho$cluster <- "Cluster 1"
+fit_smc_rho <- dplyr::group_by(fit_smc_rho, .data$cluster)
+class(fit_smc_rho) <- c(
+	"posterior_SMCMallows", "grouped_df", "tbl_df", "tbl", "data.frame"
+)
+fit_smc_post_internal_rho <- .compute_posterior_intervals(
+	fit_smc_alpha, "rho", .95, 3L, discrete = TRUE
+)
+
+# Testing classes ==============================================================
+
+test_that("Classes are correctly attributed", {
+	expect_s3_class(fit_bm, "BayesMallows")
+	expect_s3_class(fit_smc, "SMCMallows")
+	expect_s3_class(fit_bm_post_alpha, "data.frame")
+	expect_s3_class(fit_bm_post_rho, "data.frame")
+	expect_s3_class(fit_smc_post_alpha, "data.frame")
+	expect_s3_class(fit_smc_post_rho, "data.frame")
+	expect_error(.compute_posterior_intervals(fit_bm_post_alpha))
+	expect_error(.compute_posterior_intervals(fit_bm_post_rho))
+	expect_error(.compute_posterior_intervals(fit_smc_post_alpha))
+	expect_error(.compute_posterior_intervals(fit_smc_post_rho))
+	expect_s3_class(fit_bm_post_internal_alpha, "data.frame")
+	expect_s3_class(fit_bm_post_internal_rho, "data.frame")
+	expect_s3_class(fit_smc_post_internal_alpha, "data.frame")
+	expect_s3_class(fit_smc_post_internal_rho, "data.frame")
+})
+
+context("compute_consensus() classes")
+
+fit_bm_consensus_cp <- compute_consensus(fit_bm, type = "CP")
+fit_bm_consensus_map <- compute_consensus(fit_bm, type = "MAP")
+# TODO #80: add tests for SMC (compute_rho_consensus). Read
+# https://github.com/ocbe-uio/BayesMallows/issues/80#issuecomment-984444753 for
+# details
+
+test_that("Classes are correctly attributed", {
+	expect_s3_class(fit_bm_consensus_cp, "data.frame")
+	expect_s3_class(fit_bm_consensus_map, "data.frame")
+})


### PR DESCRIPTION
`compute_posterior_interval()` was wrongly using the "BayesMallows" class and passing it on to `.compute_posterior_intervals()`. The methods for the latter are now "posterior_BayesMallows" and "posterior_SMCMallows". An underscore is being used instead of a period (as opposed to the `summary.lm()` example because the dot is supposed to be reserved for splitting S3 generics and methods (too tired to insert a source here).

Changing the class was easy, but it took me so much time to write the unit tests, sorry. I'm sending this commit (8e31043ce34f8b49df25326c75f204b718d5c482) to rhub for a check against CRAN, particularly the M1 architecture. Fingers crossed.

# Summary of changes

- Changed classes for compute_posterior_interval methods (#80)
- Added tests to check BM and SMC classes (#80)
