### PR TITLE
Replaced redundancies with two functions (#112)

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -80,6 +80,33 @@ arma::uvec arma_setdiff(arma::uvec x, arma::uvec y){
   return x;
 }
 
+// This is practically a signed variation of arma_setdiff. It also uses Rcpp as
+// a crutch, so future changes that work around this and only use arma objects
+// are welcome.
+arma::vec arma_setdiff_vec(arma::vec x, arma::vec y, const bool& sort_unique = false) {
+  Rcpp::NumericVector x_Rcpp, y_Rcpp;
+  arma::vec x_y_diff;
+  x_Rcpp = x;
+  y_Rcpp = y;
+  if (sort_unique) {
+    x_y_diff = Rcpp::sort_unique(Rcpp::setdiff(x_Rcpp, y_Rcpp));
+  } else {
+    x_y_diff = Rcpp::setdiff(x_Rcpp, y_Rcpp);
+  }
+  return x_y_diff;
+}
+
+// This is practically an Rcpp variation of arma_setdiff_arma. Future changes
+// that eliminate the use of this function in favor of arma_setdiff_vec() are
+// welcome.
+Rcpp::NumericVector Rcpp_setdiff_arma(arma::ivec x, arma::vec y) {
+  Rcpp::NumericVector x_Rcpp, y_Rcpp;
+  x_Rcpp = x;
+  y_Rcpp = y;
+  Rcpp::NumericVector x_y_diff = Rcpp::setdiff(x_Rcpp, y_Rcpp);
+  return x_y_diff;
+}
+
 arma::uvec maybe_offset_indices(
   arma::vec& x,
   arma::uvec idx_x,

--- a/src/misc.h
+++ b/src/misc.h
@@ -9,6 +9,8 @@ arma::uvec std_setdiff(arma::uvec&, arma::uvec&);
 int sample_int(const arma::rowvec& probs);
 double rtruncbeta(int shape1, int shape2, double trunc = 1);
 arma::uvec arma_setdiff(arma::uvec x, arma::uvec y);
+arma::vec arma_setdiff_vec(arma::vec, arma::vec, const bool& = false);
+Rcpp::NumericVector Rcpp_setdiff_arma(arma::ivec, arma::vec);
 arma::uvec maybe_offset_indices(arma::vec&, arma::uvec, const bool& = true);
 
 #endif

--- a/src/smc_correction_kernel.cpp
+++ b/src/smc_correction_kernel.cpp
@@ -1,4 +1,5 @@
 #include "RcppArmadillo.h"
+#include "misc.h"
 
 // [[Rcpp::depends(RcppArmadillo)]]
 //' @title Correction Kernel
@@ -34,10 +35,7 @@ Rcpp::List correction_kernel(
     // resample from smaller pool of possible augmented rankings
 
     //  find elements missing from original observed ranking
-    Rcpp::NumericVector o_rank_Rcpp, c_rank_Rcpp;
-    o_rank_Rcpp = observed_ranking;
-    c_rank_Rcpp = current_ranking;
-    arma::vec remaining_set = Rcpp::setdiff(c_rank_Rcpp, o_rank_Rcpp);
+    arma::vec remaining_set = arma_setdiff_vec(current_ranking, observed_ranking);
 
     // create new agumented ranking by sampling remaining ranks from set uniformly
     proposed_ranking = observed_ranking;

--- a/src/smc_correction_kernel_pseudo.cpp
+++ b/src/smc_correction_kernel_pseudo.cpp
@@ -1,5 +1,6 @@
 #include "RcppArmadillo.h"
 #include "smc.h"
+#include "misc.h"
 
 // [[Rcpp::depends(RcppArmadillo)]]
 //' @title Correction Kernel (pseudolikelihood)
@@ -45,10 +46,7 @@ Rcpp::List correction_kernel_pseudo(
         arma::uvec unranked_items = find_nonfinite(observed_ranking);
 
         // find elements missing from original observed ranking
-        Rcpp::NumericVector o_rank_Rcpp, c_rank_Rcpp;
-        o_rank_Rcpp = observed_ranking;
-        c_rank_Rcpp = current_ranking;
-        arma::vec remaining_set = Rcpp::setdiff(c_rank_Rcpp, o_rank_Rcpp);
+        arma::vec remaining_set = arma_setdiff_vec(current_ranking, observed_ranking);
 
         // if we only have one missing rank, then we can
         if (remaining_set.n_elem == 1) {

--- a/src/smc_mallows_new_item_rank.cpp
+++ b/src/smc_mallows_new_item_rank.cpp
@@ -90,11 +90,7 @@ Rcpp::List smc_mallows_new_item_rank(
       arma::vec R_obs_slice_0_row_jj = R_obs.slice(0).row(jj).t();
       if (aug_method == "random") {
         // find elements missing from original observed ranking
-        arma::vec partial_ranking = R_obs_slice_0_row_jj;
-        Rcpp::NumericVector p_rank_Rcpp, rank_Rcpp;
-        p_rank_Rcpp = partial_ranking;
-        rank_Rcpp = ranks;
-        Rcpp::NumericVector remaining_set = Rcpp::setdiff(rank_Rcpp, p_rank_Rcpp);
+        Rcpp::NumericVector remaining_set = Rcpp_setdiff_arma(ranks, R_obs_slice_0_row_jj);
 
         // create new agumented ranking by sampling remaining ranks from set uniformly
         arma::vec rset;
@@ -104,6 +100,7 @@ Rcpp::List smc_mallows_new_item_rank(
         } else {
           rset = Rcpp::as<arma::vec>(Rcpp::sample(remaining_set, remaining_set.length()));
         }
+        arma::vec partial_ranking = R_obs_slice_0_row_jj;
         partial_ranking.elem(arma::find_nonfinite(partial_ranking)) = rset;
 
         aug_rankings.slice(ii).row(jj) = partial_ranking.t();
@@ -117,10 +114,7 @@ Rcpp::List smc_mallows_new_item_rank(
         arma::uvec unranked_items = arma::find_nonfinite(R_obs_slice_0_row_jj);
 
         // find unallocated ranks from original observed ranking
-        Rcpp::NumericVector rank_Rcpp, R_obs_slice_0_row_jj_Rcpp;
-        R_obs_slice_0_row_jj_Rcpp = R_obs_slice_0_row_jj;
-        rank_Rcpp = ranks;
-        Rcpp::NumericVector remaining_set = Rcpp::setdiff(rank_Rcpp, R_obs_slice_0_row_jj_Rcpp);
+        Rcpp::NumericVector remaining_set = Rcpp_setdiff_arma(ranks, R_obs_slice_0_row_jj);
 
         // randomly permute the unranked items to give the order in which they will be allocated
         arma::uvec item_ordering;

--- a/src/smc_mallows_new_item_rank_alpha_fixed.cpp
+++ b/src/smc_mallows_new_item_rank_alpha_fixed.cpp
@@ -1,5 +1,6 @@
 #include "RcppArmadillo.h"
 #include "smc.h"
+#include "misc.h"
 #include "partitionfuns.h"
 
 // [[Rcpp::depends(RcppArmadillo)]]
@@ -91,11 +92,7 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
         // find elements missing from original observed ranking
         arma::vec partial_ranking = R_obs_slice_0_row_jj;
 
-        Rcpp::NumericVector ranks_Cpp, partial_ranking_Cpp;
-        ranks_Cpp = ranks;
-        partial_ranking_Cpp = partial_ranking;
-        Rcpp::NumericVector remaining_set = Rcpp::setdiff(ranks_Cpp, partial_ranking_Cpp);
-
+        Rcpp::NumericVector remaining_set = Rcpp_setdiff_arma(ranks, partial_ranking);
 
         // create new agumented ranking by sampling remaining ranks from set uniformly
         arma::vec rset;
@@ -120,10 +117,7 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
         arma::uvec unranked_items = arma::find_nonfinite(R_obs_slice_0_row_jj);
 
         // find unallocated ranks from original observed ranking
-        Rcpp::NumericVector rank_Rcpp, R_obs_slice_0_row_jj_Rcpp;
-        R_obs_slice_0_row_jj_Rcpp = R_obs_slice_0_row_jj;
-        rank_Rcpp = ranks;
-        Rcpp::NumericVector remaining_set = Rcpp::setdiff(rank_Rcpp, R_obs_slice_0_row_jj_Rcpp);
+        Rcpp::NumericVector remaining_set = Rcpp_setdiff_arma(ranks, R_obs_slice_0_row_jj);
 
         // randomly permute the unranked items to give the order in which they will be allocated
         arma::uvec item_ordering;

--- a/src/smc_mallows_new_users_partial.cpp
+++ b/src/smc_mallows_new_users_partial.cpp
@@ -106,10 +106,7 @@ Rcpp::List smc_mallows_new_users_partial(
         arma::uvec unranked_items = find_nonfinite(partial_ranking);
 
         // find ranks missing from ranking
-        Rcpp::NumericVector ranks_Cpp, partial_ranking_Cpp;
-        ranks_Cpp = ranks;
-        partial_ranking_Cpp = partial_ranking;
-        Rcpp::NumericVector missing_ranks = Rcpp::sort_unique(Rcpp::setdiff(ranks_Cpp, partial_ranking_Cpp));
+        Rcpp::NumericVector missing_ranks = Rcpp::sort_unique(Rcpp_setdiff_arma(ranks, partial_ranking));
 
         // fill in missing ranks based on choice of augmentation method
         if (aug_method == "random") {

--- a/src/smc_mallows_new_users_partial_alpha_fixed.cpp
+++ b/src/smc_mallows_new_users_partial_alpha_fixed.cpp
@@ -97,10 +97,7 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
         arma::uvec unranked_items = find_nonfinite(partial_ranking);
 
         // find ranks missing from ranking
-        Rcpp::NumericVector ranks_Cpp, partial_ranking_Cpp;
-        ranks_Cpp = ranks;
-        partial_ranking_Cpp = partial_ranking;
-        Rcpp::NumericVector missing_ranks = Rcpp::setdiff(ranks_Cpp, partial_ranking_Cpp);
+        Rcpp::NumericVector missing_ranks = Rcpp_setdiff_arma(ranks, partial_ranking);
 
         // fill in missing ranks based on choice of augmentation method
         if (aug_method == "random") {

--- a/src/smc_metropolis_hastings_aug_ranking.cpp
+++ b/src/smc_metropolis_hastings_aug_ranking.cpp
@@ -1,5 +1,6 @@
 #include "RcppArmadillo.h"
 #include "smc.h"
+#include "misc.h"
 
 // [[Rcpp::depends(RcppArmadillo)]]
 //' @title Metropolis-Hastings Augmented Ranking
@@ -34,10 +35,7 @@ arma::vec metropolis_hastings_aug_ranking(
   arma::uvec unranked_items = find_nonfinite(partial_ranking);
 
   // find unallocated ranks from original observed ranking
-  Rcpp::NumericVector p_rank_Rcpp, c_rank_Rcpp;
-  p_rank_Rcpp = partial_ranking;
-  c_rank_Rcpp = current_ranking;
-  arma::vec remaining_set = Rcpp::sort_unique(Rcpp::setdiff(c_rank_Rcpp, p_rank_Rcpp));
+  arma::vec remaining_set = arma_setdiff_vec(current_ranking, partial_ranking, true);
 
 
   // if the observed and augmented ranking are exactly the same then break

--- a/src/smc_metropolis_hastings_aug_ranking_pseudo.cpp
+++ b/src/smc_metropolis_hastings_aug_ranking_pseudo.cpp
@@ -1,5 +1,6 @@
 #include "RcppArmadillo.h"
 #include "smc.h"
+#include "misc.h"
 
 // [[Rcpp::depends(RcppArmadillo)]]
 //' @title Metropolis-Hastings Augmented Ranking (pseudolikelihood)
@@ -36,10 +37,10 @@ arma::vec metropolis_hastings_aug_ranking_pseudo(
   arma::uvec unranked_items = find_nonfinite(partial_ranking);
 
   // find unallocated ranks from original observed ranking
-  Rcpp::NumericVector p_rank_Rcpp, c_rank_Rcpp;
-  p_rank_Rcpp = partial_ranking;
-  c_rank_Rcpp = current_ranking;
-  arma::vec remaining_set = Rcpp::setdiff(c_rank_Rcpp, p_rank_Rcpp);
+  // Rcpp::NumericVector p_rank_Rcpp, c_rank_Rcpp;
+  // p_rank_Rcpp = partial_ranking;
+  // c_rank_Rcpp = current_ranking;
+  arma::vec remaining_set = arma_setdiff_vec(current_ranking, partial_ranking);
 
   // if the observed and augmented ranking are exactly the same then break
   bool condition_1 = arma::approx_equal(\


### PR DESCRIPTION
New C++ functions:
- `arma_setdiff_vec()`
- `Rcpp_setdiff_arma()`

Both are slight variations of `arma_setdiff()` using different-classed
objects. Code could be later further optimized by merging the new functions
into `arma_setdiff()`.
