### PR TITLE
Replaced SMC code with functions (#112, #114)

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -126,3 +126,48 @@ arma::uvec maybe_offset_indices(
   }
   return(idx_x);
 }
+
+arma::sword sample_one_with_prob(arma::vec set, arma::vec probs) {
+  // Used in SMC to fill in the new augmented ranking going forward.
+  Rcpp::NumericVector set_Rcpp, probs_Rcpp;
+  set_Rcpp = set;
+  probs_Rcpp = probs;
+  arma::sword chosen_one = Rcpp::as<int>(Rcpp::sample(set_Rcpp, 1, false, probs_Rcpp));
+  return(chosen_one);
+}
+
+arma::uvec new_pseudo_proposal(arma::uvec items) {
+  // Used in SMC to create new agumented ranking by using pseudo proposal. This
+  // function randomly permutes the unranked items to give the order in which
+  // they will be allocated.
+  Rcpp::IntegerVector items_Rcpp;
+  items_Rcpp = items;
+  arma::uvec order;
+  order = Rcpp::as<arma::uvec>(Rcpp::sample(items_Rcpp, items_Rcpp.length())) + 1;
+  return(order);
+}
+
+double divide_by_fact(double prob, int set_length) {
+  Rcpp::NumericVector set_length_Rcpp, set_length_Rcpp_fact;
+  set_length_Rcpp = set_length;
+  set_length_Rcpp_fact = Rcpp::factorial(set_length_Rcpp);
+  prob /= Rcpp::as<double>(set_length_Rcpp_fact);
+  return(prob);
+}
+
+arma::uvec permutate_with_weights(arma::vec weights, int N) {
+  // Using weights_Rcpp so that Rcpp::sample compiles. More details on
+  // https://github.com/ocbe-uio/BayesMallows/issues/90#issuecomment-866614296
+  Rcpp::NumericVector weights_Rcpp;
+  weights_Rcpp = weights;
+  arma::uvec index;
+  index = Rcpp::as<arma::uvec>(Rcpp::sample(N, N, true, weights_Rcpp)) - 1;
+  return(index);
+}
+
+arma::vec arma_vec_seq(int N) {
+  // Creates an arma vector filled with {1,...,N}
+  Rcpp::IntegerVector vec_Rcpp = Rcpp::seq(1, N);
+  arma::vec vec = Rcpp::as<arma::vec>(vec_Rcpp);
+  return(vec);
+}

--- a/src/misc.h
+++ b/src/misc.h
@@ -12,5 +12,9 @@ arma::uvec arma_setdiff(arma::uvec x, arma::uvec y);
 arma::vec arma_setdiff_vec(arma::vec, arma::vec, const bool& = false);
 Rcpp::NumericVector Rcpp_setdiff_arma(arma::ivec, arma::vec);
 arma::uvec maybe_offset_indices(arma::vec&, arma::uvec, const bool& = true);
-
+arma::uword sample_one_with_prob(arma::vec, arma::vec);
+arma::uvec new_pseudo_proposal(arma::uvec);
+double divide_by_fact(double, int);
+arma::uvec permutate_with_weights(arma::vec, int);
+arma::vec arma_vec_seq(int);
 #endif

--- a/src/smc_calculate_forward_probability.cpp
+++ b/src/smc_calculate_forward_probability.cpp
@@ -76,10 +76,7 @@ Rcpp::List calculate_forward_probability(
       );
 
       // fill in the new augmented ranking going forward
-      Rcpp::NumericVector rs, spl;
-      rs = remaining_set;
-      spl = sample_prob_list;
-      auxiliary_ranking(jj) = Rcpp::as<int>(Rcpp::sample(rs, 1, false, spl));
+      auxiliary_ranking(jj) = sample_one_with_prob(remaining_set, sample_prob_list);
 
       // save the probability of selecting the specific item rank in the old
       // augmented ranking

--- a/src/smc_correction_kernel.cpp
+++ b/src/smc_correction_kernel.cpp
@@ -48,14 +48,7 @@ Rcpp::List correction_kernel(
       remaining_set = std::move(arma::shuffle(remaining_set));
       proposed_ranking.elem(unranked_items) = remaining_set;
     }
-
-    Rcpp::NumericVector remaining_set_Rcpp;
-    remaining_set_Rcpp = remaining_set;
-    Rcpp::NumericVector remaining_set_Rcpp_elem;
-    remaining_set_Rcpp_elem = remaining_set_Rcpp.length();
-    const Rcpp::NumericVector remaining_set_fact = Rcpp::factorial(remaining_set_Rcpp_elem);
-    const double remaining_set_fact_dbl = Rcpp::as<double>(remaining_set_fact);
-    correction_prob = 1.0 / remaining_set_fact_dbl;
+    correction_prob = divide_by_fact(correction_prob, remaining_set.n_elem);
   }
   return Rcpp::List::create(
       Rcpp::Named("ranking") = proposed_ranking,

--- a/src/smc_correction_kernel_pseudo.cpp
+++ b/src/smc_correction_kernel_pseudo.cpp
@@ -54,12 +54,7 @@ Rcpp::List correction_kernel_pseudo(
             observed_ranking.elem(unranked_items) = remaining_set;
         } else {
             // create new agumented ranking by using pseudo proposal
-            Rcpp::IntegerVector unranked_items_Rcpp;
-            unranked_items_Rcpp = arma::conv_to<arma::ivec>::from(unranked_items);
-            arma::uvec item_ordering = Rcpp::as<arma::uvec>(\
-                Rcpp::sample(unranked_items_Rcpp, unranked_items_Rcpp.length())\
-            );
-            item_ordering = item_ordering + 1;
+            arma::uvec item_ordering = new_pseudo_proposal(unranked_items);
 
             // item ordering is the order of which items are assigned ranks in a specified order
             const arma::uword& num_items_unranked = item_ordering.n_elem;
@@ -88,10 +83,7 @@ Rcpp::List correction_kernel_pseudo(
                 );
 
                 // fill in the new augmented ranking going forward
-                Rcpp::NumericVector rs, spl;
-                rs = remaining_set;
-                spl = sample_prob_list;
-                auxiliary_ranking(jj) = Rcpp::as<int>(Rcpp::sample(rs, 1, false, spl));
+                auxiliary_ranking(jj) = sample_one_with_prob(remaining_set, sample_prob_list);
 
                 // save the probability of selecting the specific item rank in the old
                 // augmented ranking

--- a/src/smc_mallows_new_item_rank.cpp
+++ b/src/smc_mallows_new_item_rank.cpp
@@ -104,11 +104,7 @@ Rcpp::List smc_mallows_new_item_rank(
         partial_ranking.elem(arma::find_nonfinite(partial_ranking)) = rset;
 
         aug_rankings.slice(ii).row(jj) = partial_ranking.t();
-        Rcpp::NumericVector remaining_set_length_Rcpp, remaining_set_length_Rcpp_fact;
-        remaining_set_length_Rcpp = remaining_set_length;
-        remaining_set_length_Rcpp_fact = Rcpp::factorial(remaining_set_length_Rcpp);
-        const double& remaining_set_length_Rcpp_fact_dbl = Rcpp::as<double>(remaining_set_length_Rcpp_fact);
-        total_correction_prob(ii) = total_correction_prob(ii) * (1 / remaining_set_length_Rcpp_fact_dbl);
+        total_correction_prob(ii) = divide_by_fact(total_correction_prob(ii), remaining_set_length);
       } else if ((aug_method == "pseudolikelihood") & ((metric == "footrule") | (metric == "spearman"))) {
         // find items missing from original observed ranking
         const arma::uvec& unranked_items = arma::find_nonfinite(R_obs_slice_0_row_jj);
@@ -171,13 +167,7 @@ Rcpp::List smc_mallows_new_item_rank(
   /* Resample                                               */
   /* ====================================================== */
   /* Resample particles using multinomial resampling ------ */
-  // Using norm_wgt_rcpp so that Rcpp::sample compiles. More details on
-  // https://github.com/ocbe-uio/BayesMallows/issues/90#issuecomment-866614296
-  Rcpp::NumericVector norm_wgt_rcpp;
-  norm_wgt_rcpp = norm_wgt;
-  arma::uvec index;
-  index = Rcpp::as<arma::uvec>(Rcpp::sample(N, N, true, norm_wgt_rcpp));
-  index -= 1;
+  arma::uvec index = permutate_with_weights(norm_wgt, N);
   rho_samples.slice(0) = rho_samples.slice(0).rows(index);
   const arma::vec& asc = alpha_samples.col(0);
   alpha_samples.col(0) = asc.elem(index);
@@ -295,13 +285,7 @@ Rcpp::List smc_mallows_new_item_rank(
     /* Resample                                               */
     /* ====================================================== */
     /* Resample particles using multinomial resampling ------ */
-    // Using norm_wgt_rcpp so that Rcpp::sample compiles. More details on
-    // https://github.com/ocbe-uio/BayesMallows/issues/90#issuecomment-866614296
-    Rcpp::NumericVector norm_wgt_rcpp;
-    norm_wgt_rcpp = norm_wgt;
-    arma::uvec index;
-    index = Rcpp::as<arma::uvec>(Rcpp::sample(N, N, true, norm_wgt_rcpp));
-    index -= 1;
+    arma::uvec index = permutate_with_weights(norm_wgt, N);
     rho_samples.slice(tt + 1) = rho_samples.slice(tt + 1).rows(index);
     const arma::vec& asc = alpha_samples.col(tt + 1);
     alpha_samples.col(tt + 1) = asc.elem(index);

--- a/src/smc_mallows_new_item_rank_alpha_fixed.cpp
+++ b/src/smc_mallows_new_item_rank_alpha_fixed.cpp
@@ -107,11 +107,7 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
 
         aug_rankings.slice(ii).row(jj) = partial_ranking.t();
         // fill in missing ranks based on choice of augmentation method
-        Rcpp::NumericVector remaining_set_length_Rcpp, remaining_set_length_Rcpp_fact;
-        remaining_set_length_Rcpp = remaining_set_length;
-        remaining_set_length_Rcpp_fact = Rcpp::factorial(remaining_set_length_Rcpp);
-        const double& remaining_set_length_Rcpp_fact_dbl = Rcpp::as<double>(remaining_set_length_Rcpp_fact);
-        total_correction_prob(ii) = total_correction_prob(ii) * (1 / remaining_set_length_Rcpp_fact_dbl);
+        total_correction_prob(ii) = divide_by_fact(total_correction_prob(ii), remaining_set_length);
       } else if ((aug_method == "pseudolikelihood") & ((metric == "footrule") | (metric == "spearman"))) {
         // find items missing from original observed ranking
         const arma::uvec& unranked_items = arma::find_nonfinite(R_obs_slice_0_row_jj);
@@ -176,14 +172,7 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
   /* Resample                                               */
   /* ====================================================== */
   /* Resample particles using multinomial resampling ------ */
-  // Using norm_wgt_rcpp so that Rcpp::sample compiles. More details on
-  // https://github.com/ocbe-uio/BayesMallows/issues/90#issuecomment-866614296
-  Rcpp::NumericVector norm_wgt_rcpp;
-  norm_wgt_rcpp = norm_wgt;
-  arma::uvec index;
-  index = Rcpp::as<arma::uvec>(Rcpp::sample(N, N, true, norm_wgt_rcpp));
-  index -= 1;
-  // index <- sample(1:N, prob = norm_wgt, size = N, replace = T)
+  arma::uvec index = permutate_with_weights(norm_wgt, N);
   rho_samples.slice(0) = rho_samples.slice(0).rows(index);
   aug_rankings = aug_rankings.slices(index);
 
@@ -291,13 +280,7 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
     /* Resample                                               */
     /* ====================================================== */
     /* Resample particles using multinomial resampling ------ */
-    // Using norm_wgt_rcpp so that Rcpp::sample compiles. More details on
-    // https://github.com/ocbe-uio/BayesMallows/issues/90#issuecomment-866614296
-    Rcpp::NumericVector norm_wgt_rcpp;
-    norm_wgt_rcpp = norm_wgt;
-    arma::uvec index;
-    index = Rcpp::as<arma::uvec>(Rcpp::sample(N, N, true, norm_wgt_rcpp));
-    index -= 1;
+    arma::uvec index = permutate_with_weights(norm_wgt, N);
     rho_samples.slice(tt + 1) = rho_samples.slice(tt + 1).rows(index);
 
     /* ====================================================== */

--- a/src/smc_mallows_new_users_complete.cpp
+++ b/src/smc_mallows_new_users_complete.cpp
@@ -152,13 +152,8 @@ Rcpp::List smc_mallows_new_users_complete(
     /* ====================================================== */
 
     /* Resample particles using multinomial resampling ------ */
-    // Using norm_wgt_rcpp so that Rcpp::sample compiles. More details on
-    // https://github.com/ocbe-uio/BayesMallows/issues/90#issuecomment-866614296
-    Rcpp::NumericVector norm_wgt_rcpp;
-    norm_wgt_rcpp = norm_wgt;
-    arma::uvec index, tt_vec;
-    index = Rcpp::as<arma::uvec>(Rcpp::sample(N, N, true, norm_wgt_rcpp));
-    index = index - 1;
+    arma::uvec index = permutate_with_weights(norm_wgt, N);
+    arma::uvec tt_vec;
     tt_vec = tt;
 
     /* Replacing tt + 1 slice on rho_samples ---------------- */

--- a/src/smc_mallows_new_users_partial_alpha_fixed.cpp
+++ b/src/smc_mallows_new_users_partial_alpha_fixed.cpp
@@ -109,9 +109,7 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
           }
 
           aug_rankings(arma::span(jj), arma::span::all, arma::span(ii)) = partial_ranking;
-          const int& missing_ranks_length = missing_ranks.length();
-          const int& missing_ranks_length_fact = factorial(missing_ranks_length); // from misc.h
-          aug_prob(ii) = aug_prob(ii) * (1.0 / missing_ranks_length_fact);
+          aug_prob(ii) = divide_by_fact(aug_prob(ii), missing_ranks.length());
         } else if ((aug_method == "pseudolikelihood") & ((metric == "footrule") | (metric == "spearman"))) {
           // randomly permute the unranked items to give the order in which they will be allocated
           arma::uvec item_ordering;
@@ -167,23 +165,18 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
     /* ====================================================== */
 
     /* Resample particles using multinomial resampling ------ */
-    // Using norm_wgt_rcpp so that Rcpp::sample compiles. More details on
-    // https://github.com/ocbe-uio/BayesMallows/issues/90#issuecomment-866614296
-    Rcpp::NumericVector norm_wgt_rcpp;
-    norm_wgt_rcpp = norm_wgt;
-    arma::uvec tt_vec, indices;
-    indices = Rcpp::as<arma::uvec>(Rcpp::sample(N, N, true, norm_wgt_rcpp));
-    indices = indices - 1;
+    arma::uvec index = permutate_with_weights(norm_wgt, N);
+    arma::uvec tt_vec;
     tt_vec = tt;
 
     /* Replacing tt + 1 slice on rho_samples ---------------- */
     arma::mat rho_samples_slice_11p1 = rho_samples.slice(tt + 1);
-    rho_samples_slice_11p1 = rho_samples_slice_11p1.rows(indices);
+    rho_samples_slice_11p1 = rho_samples_slice_11p1.rows(index);
     rho_samples.slice(tt + 1) = rho_samples_slice_11p1;
 
     /* Replacing tt + 1 column on alpha_samples ------------- */
-    const arma::cube& aug_rankings_indices = aug_rankings.slices(indices);
-    aug_rankings.rows(0, num_obs - 1) = aug_rankings_indices(arma::span(0, num_obs - 1), arma::span::all, arma::span::all);
+    const arma::cube& aug_rankings_index = aug_rankings.slices(index);
+    aug_rankings.rows(0, num_obs - 1) = aug_rankings_index(arma::span(0, num_obs - 1), arma::span::all, arma::span::all);
 
     /* ====================================================== */
     /* Move step                                              */

--- a/src/smc_metropolis_hastings_aug_ranking.cpp
+++ b/src/smc_metropolis_hastings_aug_ranking.cpp
@@ -27,9 +27,7 @@ arma::vec metropolis_hastings_aug_ranking(
 	const std::string metric
 ) {
   // augment incomplete ranks to initialise
-  arma::vec ranks;
-  const Rcpp::IntegerVector tmp = Rcpp::seq(1, n_items);
-  ranks = Rcpp::as<arma::vec>(tmp);
+  arma::vec ranks = arma_vec_seq(n_items);
 
   // find items missing from original observed ranking
   const arma::uvec unranked_items = find_nonfinite(partial_ranking);

--- a/src/smc_metropolis_hastings_aug_ranking_pseudo.cpp
+++ b/src/smc_metropolis_hastings_aug_ranking_pseudo.cpp
@@ -29,17 +29,12 @@ arma::vec metropolis_hastings_aug_ranking_pseudo(
 	const std::string metric
 ) {
   // augment incomplete ranks to initialise
-  arma::vec ranks;
-  const Rcpp::IntegerVector tmp = Rcpp::seq(1, n_items);
-  ranks = Rcpp::as<arma::vec>(tmp);
+  arma::vec ranks = arma_vec_seq(n_items);
 
   // find items missing from original observed ranking
   const arma::uvec unranked_items = find_nonfinite(partial_ranking);
 
   // find unallocated ranks from original observed ranking
-  // Rcpp::NumericVector p_rank_Rcpp, c_rank_Rcpp;
-  // p_rank_Rcpp = partial_ranking;
-  // c_rank_Rcpp = current_ranking;
   const arma::vec remaining_set = arma_setdiff_vec(current_ranking, partial_ranking);
 
   // if the observed and augmented ranking are exactly the same then break
@@ -52,12 +47,7 @@ arma::vec metropolis_hastings_aug_ranking_pseudo(
   } else {
     // randomly permute the unranked items to give the order in which they will
     // be allocated
-    Rcpp::IntegerVector unranked_items_Rcpp;
-    unranked_items_Rcpp = arma::conv_to<arma::ivec>::from(unranked_items);
-    arma::uvec item_ordering = Rcpp::as<arma::uvec>(\
-      Rcpp::sample(unranked_items_Rcpp, unranked_items_Rcpp.length())\
-    );
-    item_ordering += 1;
+    arma::uvec item_ordering = new_pseudo_proposal(unranked_items);
 
     // Calculate probabilities
     const Rcpp::List proposal = calculate_forward_probability(\


### PR DESCRIPTION
This PR intends to close issue #112.

Duplicated code on SMC functions that involved the creation of "crutch" Rcpp elements was removed and turned into functions, then reduced as much as I could to minimize the usage of Rcpp objects. This could not be 100% avoided since the functions use Rcpp functions (which naturally expects Rcpp vectors instead of Arma ones).

This should take care of the remaining task of issue #112. It also helps with #114 by reducing code redundancy.

