### PR TITLE
Fix oldrel errors

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -51,7 +51,8 @@ jobs:
               "inst/examples/label_switching_example.R",
               "inst/examples/obs_freq_example.R",
               "inst/examples/plot_top_k_example.R",
-              "inst/examples/plot.BayesMallows_example.R"
+              "inst/examples/plot.BayesMallows_example.R",
+              "R/RcppExports.R"
             )
             style_rules <- list(
               absolute_path_linter, assignment_linter, closed_curly_linter,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BayesMallows
 Type: Package
 Title: Bayesian Preference Learning with the Mallows Rank Model
-Version: 1.1.0.9000
+Version: 1.1.0.9001
 Authors@R: c(person("Oystein", "Sorensen",
                     email = "oystein.sorensen.1985@gmail.com",
                     role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BayesMallows
 Type: Package
 Title: Bayesian Preference Learning with the Mallows Rank Model
-Version: 1.1.0.9001
+Version: 1.1.0.9002
 Authors@R: c(person("Oystein", "Sorensen",
                     email = "oystein.sorensen.1985@gmail.com",
                     role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# BayesMallows (development version)
+
 # BayesMallows 1.1.0
 
 * Major update, introducing a whole new class of methods using sequential Monte Carlo. Also reducing the number of dependencies.

--- a/R/smc_post_processing_functions.R
+++ b/R/smc_post_processing_functions.R
@@ -27,10 +27,9 @@ smc_processing <- function(output, colnames = NULL) {
     new.row.names = seq_len(prod(dim(df))),
     v.names = "value",
     timevar = "item",
-    idvar = NULL,
     times = names(df)
   )
-  attr(x = new_df, "reshapeLong") <- NULL # preserves identity to gather output
+  new_df <- new_df[, -3] # drop the "id" column
   class(new_df) <- c("SMCMallows", "data.frame")
   return(new_df)
 }

--- a/src/distances.cpp
+++ b/src/distances.cpp
@@ -37,7 +37,7 @@ double kendall_distance(const arma::vec& r1, const arma::vec& r2){
 
   for(int i = 0; i < n; ++i){
     for(int j = 0; j < i; ++j){
-      if(((r1(j) > r1(i)) & (r2(j) < r2(i)) ) || ((r1(j) < r1(i)) & (r2(j) > r2(i)))) {
+      if (((r1(j) > r1(i)) && (r2(j) < r2(i)) ) || ((r1(j) < r1(i)) && (r2(j) > r2(i)))) {
         distance += 1;
       }
     }
@@ -141,6 +141,3 @@ arma::vec rank_dist_vec(const arma::mat& rankings,
   }
   return(result);
 }
-
-
-

--- a/src/leapandshift.cpp
+++ b/src/leapandshift.cpp
@@ -55,7 +55,7 @@ void leap_and_shift(arma::vec& rho_proposal, arma::uvec& indices,
   double length1 = std::min(rho(u - 1) - 1, dobL);
   double length2 = std::min(n - rho(u - 1), dobL);
 
-  if((rho(u - 1) > 1) & (rho(u - 1) < n)){
+  if ((rho(u - 1) > 1) && (rho(u - 1) < n)) {
     support = arma::join_cols(arma::linspace(
       std::max(1.0, rho(u - 1) - leap_size), rho(u - 1) - 1, length1),
       arma::linspace(rho(u - 1) + 1, std::min(dobn, rho(u - 1) + leap_size), length2));
@@ -90,6 +90,3 @@ void leap_and_shift(arma::vec& rho_proposal, arma::uvec& indices,
     indices = arma::regspace<arma::uvec>(0, n - 1);
   }
 }
-
-
-

--- a/src/rmallows.cpp
+++ b/src/rmallows.cpp
@@ -71,7 +71,7 @@ arma::mat rmallows(
                    rho_iter, leap_size, true);
 
     // These distances do not work with the computational shortcut
-    if((metric == "cayley") | (metric == "ulam")){
+    if ((metric == "cayley") || (metric == "ulam")) {
       indices = arma::regspace<arma::uvec>(0, n_items - 1);
     }
 
@@ -100,6 +100,3 @@ arma::mat rmallows(
   }
   return rho;
 }
-
-
-

--- a/src/smc_leap_and_shift_probs.cpp
+++ b/src/smc_leap_and_shift_probs.cpp
@@ -56,9 +56,9 @@ Rcpp::List leap_and_shift_probs(const arma::vec rho, const int leap_size, const 
   for (int i = 0; i < n_items; ++i) {
     if (rho(i) == rho(u)) {
       rho_prime(i) = rho_star(u);
-    } else if ((rho(u) < rho(i)) & (rho(i) <= rho_star(u)) & (delta > 0)) {
+    } else if ((rho(u) < rho(i)) && (rho(i) <= rho_star(u)) && (delta > 0)) {
       rho_prime(i) = rho(i) - 1;
-    } else if ((rho(u) > rho(i)) & (rho(i) >= rho_star(u)) & (delta < 0)) {
+    } else if ((rho(u) > rho(i)) && (rho(i) >= rho_star(u)) && (delta < 0)) {
       rho_prime(i) = rho(i) + 1;
     } else {
       rho_prime(i) = rho(i);

--- a/src/smc_mallows_new_item_rank.cpp
+++ b/src/smc_mallows_new_item_rank.cpp
@@ -105,7 +105,7 @@ Rcpp::List smc_mallows_new_item_rank(
 
         aug_rankings.slice(ii).row(jj) = partial_ranking.t();
         total_correction_prob(ii) = divide_by_fact(total_correction_prob(ii), remaining_set_length);
-      } else if ((aug_method == "pseudolikelihood") & ((metric == "footrule") | (metric == "spearman"))) {
+      } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
         // find items missing from original observed ranking
         const arma::uvec& unranked_items = arma::find_nonfinite(R_obs_slice_0_row_jj);
 
@@ -193,7 +193,7 @@ Rcpp::List smc_mallows_new_item_rank(
           alpha_samples(ii, 0), rho_samples.slice(0).row(ii).t(), n_items,\
           R_obs.slice(0).row(jj).t(), aug_rankings.slice(ii).row(jj).t(), metric\
         );
-      } else if ((aug_method == "pseudolikelihood") & ((metric == "footrule") | (metric == "spearman"))) {
+      } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
         mh_aug_result = metropolis_hastings_aug_ranking_pseudo(\
           alpha_samples(ii, 0), rho_samples.slice(0).row(ii).t(), n_items,\
           R_obs.slice(0).row(jj).t(), aug_rankings.slice(ii).row(jj).t(), metric\
@@ -236,7 +236,7 @@ Rcpp::List smc_mallows_new_item_rank(
           const double c_prob = check_correction["correction_prob"];
           aug_rankings.slice(ii).row(jj) = c_rank.t();
           particle_correction_prob(ii) *= c_prob;
-        } else if ((aug_method == "pseudolikelihood") & ((metric == "footrule") | (metric == "spearman"))) {
+        } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
           const Rcpp::List check_correction = correction_kernel_pseudo(\
             aug_rankings.slice(ii).row(jj).t(), R_obs.slice(tt + 1).row(jj).t(),\
             rho_samples.slice(tt + 1).row(ii).t(), alpha_samples(ii, tt + 1),\
@@ -312,7 +312,7 @@ Rcpp::List smc_mallows_new_item_rank(
             n_items, R_obs.slice(tt + 1).row(jj).t(),\
             aug_rankings.slice(ii).row(jj).t(), metric\
           );
-        } else if ((aug_method == "pseudolikelihood") & ((metric == "footrule") | (metric == "spearman"))) {
+        } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
           mh_aug_result = metropolis_hastings_aug_ranking_pseudo(\
             alpha_samples(ii, tt + 1), rho_samples.slice(tt + 1).row(ii).t(),\
             n_items, R_obs.slice(tt + 1).row(jj).t(),\

--- a/src/smc_mallows_new_item_rank_alpha_fixed.cpp
+++ b/src/smc_mallows_new_item_rank_alpha_fixed.cpp
@@ -108,7 +108,7 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
         aug_rankings.slice(ii).row(jj) = partial_ranking.t();
         // fill in missing ranks based on choice of augmentation method
         total_correction_prob(ii) = divide_by_fact(total_correction_prob(ii), remaining_set_length);
-      } else if ((aug_method == "pseudolikelihood") & ((metric == "footrule") | (metric == "spearman"))) {
+      } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
         // find items missing from original observed ranking
         const arma::uvec& unranked_items = arma::find_nonfinite(R_obs_slice_0_row_jj);
 
@@ -191,7 +191,7 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
           alpha, rho_samples.slice(0).row(ii).t(), n_items,\
           R_obs.slice(0).row(jj).t(), aug_rankings.slice(ii).row(jj).t(), metric\
         );
-      } else if ((aug_method == "pseudolikelihood") & ((metric == "footrule") | (metric == "spearman"))) {
+      } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
         mh_aug_result = metropolis_hastings_aug_ranking_pseudo(\
           alpha, rho_samples.slice(0).row(ii).t(), n_items,\
           R_obs.slice(0).row(jj).t(), aug_rankings.slice(ii).row(jj).t(), metric\
@@ -232,7 +232,7 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
           double c_prob = check_correction["correction_prob"];
           aug_rankings.slice(ii).row(jj) = c_rank.t();
           total_correction_prob(ii) *= c_prob;
-        } else if ((aug_method == "pseudolikelihood") & ((metric == "footrule") | (metric == "spearman"))) {
+        } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
           Rcpp::List check_correction = correction_kernel_pseudo(\
             aug_rankings.slice(ii).row(jj).t(), R_obs.slice(tt + 1).row(jj).t(),\
             rho_samples.slice(tt + 1).row(ii).t(), alpha, n_items, metric\
@@ -299,7 +299,7 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
             n_items, R_obs.slice(tt + 1).row(jj).t(),\
             aug_rankings.slice(ii).row(jj).t(), metric\
           );
-        } else if ((aug_method == "pseudolikelihood") & ((metric == "footrule") | (metric == "spearman"))) {
+        } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
           mh_aug_result = metropolis_hastings_aug_ranking_pseudo(\
             alpha, rho_samples.slice(tt + 1).row(ii).t(),\
             n_items, R_obs.slice(tt + 1).row(jj).t(),\

--- a/src/smc_mallows_new_users_partial.cpp
+++ b/src/smc_mallows_new_users_partial.cpp
@@ -121,7 +121,7 @@ Rcpp::List smc_mallows_new_users_partial(
           aug_rankings(arma::span(jj), arma::span::all, arma::span(ii)) = partial_ranking;
           aug_prob(ii) = divide_by_fact(aug_prob(ii), missing_ranks.length());
 
-        } else if ((aug_method == "pseudolikelihood") & ((metric == "footrule") | (metric == "spearman"))) {
+        } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
 
           // randomly permute the unranked items to give the order in which they will be allocated
           arma::uvec item_ordering;
@@ -219,7 +219,7 @@ Rcpp::List smc_mallows_new_users_partial(
         arma::vec mh_aug_result;
         if (aug_method == "random") {
           mh_aug_result = metropolis_hastings_aug_ranking(as, rs.t(), n_items, R_obs.row(jj).t(), ar.t(), metric);
-        } else if ((aug_method == "pseudolikelihood") & ((metric == "footrule") | (metric == "spearman"))) {
+        } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
           mh_aug_result = metropolis_hastings_aug_ranking_pseudo(as, rs.t(), n_items, R_obs.row(jj).t(), ar.t(), metric);
         }
         aug_rankings(arma::span(jj), arma::span::all, arma::span(ii)) = mh_aug_result;

--- a/src/smc_mallows_new_users_partial_alpha_fixed.cpp
+++ b/src/smc_mallows_new_users_partial_alpha_fixed.cpp
@@ -110,7 +110,7 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
 
           aug_rankings(arma::span(jj), arma::span::all, arma::span(ii)) = partial_ranking;
           aug_prob(ii) = divide_by_fact(aug_prob(ii), missing_ranks.length());
-        } else if ((aug_method == "pseudolikelihood") & ((metric == "footrule") | (metric == "spearman"))) {
+        } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
           // randomly permute the unranked items to give the order in which they will be allocated
           arma::uvec item_ordering;
           item_ordering = arma::conv_to<arma::uvec>::from(arma::shuffle(unranked_items));
@@ -200,7 +200,7 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
           mh_aug_result = metropolis_hastings_aug_ranking(\
           alpha, rs.t(), n_items, R_obs.row(jj).t(), ar.t(), metric\
         );
-        } else if ((aug_method == "pseudolikelihood") & ((metric == "footrule") | (metric == "spearman"))) {
+        } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
           mh_aug_result = metropolis_hastings_aug_ranking_pseudo(
             alpha, rs.t(), n_items, R_obs.row(jj).t(), ar.t(), metric\
           );


### PR DESCRIPTION
# Summary

Couldn't reproduce the error, but looking at the log tracebacks I see they were caused by a call to `stats::reshape()` inside `smc_processing()`, particularly when the former tries to compute `ids <- data[, idvar]`. Understandably, since `smc_processing()` was calling `reshape()` with `idvar = NULL`, this would cause a problem on the computation of `ids`. Therefore, I propose a workaround that uses the default of `idvar = "id"` and then drops that extra `id` column. The end result (`new_df`) should be the same.

# Commits

- Refactored reshaping on smc_processing() #174
- Excluding RcppExports.R from linter
- Increment version number to 1.1.0.9002
