### PR TITLE
Update smc_mallows_new_users_partial.cpp

### DIFF
--- a/src/smc_mallows_new_users_partial.cpp
+++ b/src/smc_mallows_new_users_partial.cpp
@@ -68,7 +68,7 @@ Rcpp::List smc_mallows_new_users_partial(
   alpha_samples.col(0) = alpha_samples_0;
   
   /* generate vector to store ESS */
-  arma::vec ESS_vec = (Time, arma::fill::zeros);
+  rowvec ESS_vec(Time);
   
   // this is to store the augmentations of the observed rankings for each particle
   arma::cube aug_rankings(n_users, n_items, N, arma::fill::zeros); // no. users by items by particles
@@ -178,7 +178,7 @@ Rcpp::List smc_mallows_new_users_partial(
     arma::vec w = arma::exp(log_inc_wgt - maxw);
     arma::vec norm_wgt = w / arma::sum(w);
     
-    ESS_vec(tt) = 1/sum(norm_wgt^2);
+    ESS_vec(tt) = (sum(norm_wgt) * sum(norm_wgt)) / sum(norm_wgt % norm_wgt);
 
     /* ====================================================== */
     /* Resample                                               */

--- a/src/smc_mallows_new_users_partial.cpp
+++ b/src/smc_mallows_new_users_partial.cpp
@@ -66,7 +66,10 @@ Rcpp::List smc_mallows_new_users_partial(
   arma::mat alpha_samples(N, Time + 1);
   const arma::vec& alpha_samples_0 = Rcpp::rexp(N, 1);
   alpha_samples.col(0) = alpha_samples_0;
-
+  
+  /* generate vector to store ESS */
+  arma::vec ESS_vec = (Time, arma::fill::zeros);
+  
   // this is to store the augmentations of the observed rankings for each particle
   arma::cube aug_rankings(n_users, n_items, N, arma::fill::zeros); // no. users by items by particles
 
@@ -174,6 +177,8 @@ Rcpp::List smc_mallows_new_users_partial(
     double maxw = arma::max(log_inc_wgt);
     arma::vec w = arma::exp(log_inc_wgt - maxw);
     arma::vec norm_wgt = w / arma::sum(w);
+    
+    ESS_vec(tt) = 1/sum(norm_wgt^2);
 
     /* ====================================================== */
     /* Resample                                               */
@@ -229,6 +234,8 @@ Rcpp::List smc_mallows_new_users_partial(
   // return the history of the particles and their values
   return Rcpp::List::create(
     Rcpp::Named("rho_samples") = rho_samples,
-    Rcpp::Named("alpha_samples") = alpha_samples
+    Rcpp::Named("alpha_samples") = alpha_samples,
+    Rcpp:Named("augmented_rankings") = aug_rankings,
+    Rcpp::Named("ESS") = ESS_vec
   );
 }

--- a/src/smc_mallows_new_users_partial.cpp
+++ b/src/smc_mallows_new_users_partial.cpp
@@ -31,7 +31,8 @@ using namespace arma;
 //' @param aug_method A character string specifying the approach for filling in the missing data, options are "pseudolikelihood" or "random"
 //' @param verbose Logical specifying whether to print out the progress of the
 //' SMC-Mallows algorithm. Defaults to \code{FALSE}.
-//' @return a set of particles each containing the values of rho and alpha and the effective sample size (ESS) at each iteration of the SMC algorithm as well as the set of augmented rankings at the final iteration.
+//' @return a set of particles each containing the values of rho and alpha and the effective sample size (ESS) at each iteration of the SMC 
+//' algorithm as well as the set of augmented rankings at the final iteration.
 //' @export
 // [[Rcpp::export]]
 Rcpp::List smc_mallows_new_users_partial(

--- a/src/smc_mallows_new_users_partial.cpp
+++ b/src/smc_mallows_new_users_partial.cpp
@@ -31,7 +31,7 @@ using namespace arma;
 //' @param aug_method A character string specifying the approach for filling in the missing data, options are "pseudolikelihood" or "random"
 //' @param verbose Logical specifying whether to print out the progress of the
 //' SMC-Mallows algorithm. Defaults to \code{FALSE}.
-//' @return a set of particles each containing a value of rho and alpha
+//' @return a set of particles each containing the values of rho and alpha and the effective sample size (ESS) at each iteration of the SMC algorithm as well as the set of augmented rankings at the final iteration.
 //' @export
 // [[Rcpp::export]]
 Rcpp::List smc_mallows_new_users_partial(

--- a/src/smc_mallows_new_users_partial.cpp
+++ b/src/smc_mallows_new_users_partial.cpp
@@ -68,10 +68,10 @@ Rcpp::List smc_mallows_new_users_partial(
   mat alpha_samples(N, Time + 1);
   const vec& alpha_samples_0 = Rcpp::rexp(N, 1);
   alpha_samples.col(0) = alpha_samples_0;
-  
+
   /* generate vector to store ESS */
   rowvec ESS_vec(Time);
-  
+
   // this is to store the augmentations of the observed rankings for each particle
   cube aug_rankings(n_users, n_items, N, fill::zeros); // no. users by items by particles
 
@@ -179,7 +179,7 @@ Rcpp::List smc_mallows_new_users_partial(
     double maxw = max(log_inc_wgt);
     vec w = exp(log_inc_wgt - maxw);
     vec norm_wgt = w / sum(w);
-    
+
     ESS_vec(tt) = (sum(norm_wgt) * sum(norm_wgt)) / sum(norm_wgt % norm_wgt);
 
     /* ====================================================== */
@@ -237,7 +237,7 @@ Rcpp::List smc_mallows_new_users_partial(
   return Rcpp::List::create(
     Rcpp::Named("rho_samples") = rho_samples,
     Rcpp::Named("alpha_samples") = alpha_samples,
-    Rcpp:Named("augmented_rankings") = aug_rankings,
+    Rcpp::Named("augmented_rankings") = aug_rankings,
     Rcpp::Named("ESS") = ESS_vec
   );
 }

--- a/tests/testthat/test-smc_mallows_partial_rankings.R
+++ b/tests/testthat/test-smc_mallows_partial_rankings.R
@@ -142,7 +142,7 @@ test_that("Runs with unif kernel", {
     aug_method      = "random"
   )
   expect_is(smc_unif, "list")
-  expect_equal(length(smc_unif), 2)
+  expect_equal(length(smc_unif), 4)
   expect_equal(dim(smc_unif$rho_samples), c(N, 10, 21))
   expect_equal(dim(smc_unif$alpha_samples), c(N, 21))
 
@@ -189,7 +189,7 @@ test_that("Runs with pseudo kernel", {
     aug_method      = "pseudolikelihood"
   )
   expect_is(smc_pseudo, "list")
-  expect_equal(length(smc_pseudo), 2)
+  expect_equal(length(smc_pseudo), 4)
   expect_equal(dim(smc_pseudo$rho_samples), c(N, 10, 21))
   expect_equal(dim(smc_pseudo$alpha_samples), c(N, 21))
 })


### PR DESCRIPTION
Include a vector named `ESS_vec` (a vector of length Time) which contains the Effective Sample Size of the particles in each iteration.
Return the `aug_rankings` at end of SMC algorithm.