### PR TITLE
Update smc_mallows_new_users_partial_alpha_fixed.cpp

### DIFF
--- a/src/smc_mallows_new_users_partial_alpha_fixed.cpp
+++ b/src/smc_mallows_new_users_partial_alpha_fixed.cpp
@@ -53,6 +53,9 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
       rho_samples(i, j, 0) = items_sample(j);
     }
   }
+  
+  /* generate vector to store ESS */
+  arma::vec ESS_vec = (Time, arma::fill::zeros);
 
   // this is to store the augmentations of the observed rankings for each particle
   arma::cube aug_rankings(n_users, n_items, N, arma::fill::zeros); // no. users by items by particles
@@ -159,6 +162,8 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
     const double maxw = arma::max(log_inc_wgt);
     const arma::vec w = arma::exp(log_inc_wgt - maxw);
     const arma::vec norm_wgt = w / arma::sum(w);
+    
+    ESS_vec(tt) = 1/sum(norm_wgt^2);
 
     /* ====================================================== */
     /* Resample                                               */
@@ -210,5 +215,7 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
     }
   }
   // return the history of the particles and their values
-  return Rcpp::List::create((Rcpp::Named("rho_samples") = rho_samples));
+  return Rcpp::List::create((Rcpp::Named("rho_samples") = rho_samples,
+                             Rcpp:Named("augmented_rankings") = aug_rankings,
+                             Rcpp::Named("ESS") = ESS_vec));
 }

--- a/src/smc_mallows_new_users_partial_alpha_fixed.cpp
+++ b/src/smc_mallows_new_users_partial_alpha_fixed.cpp
@@ -55,7 +55,7 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
       rho_samples(i, j, 0) = items_sample(j);
     }
   }
-  
+
   /* generate vector to store ESS */
   rowvec ESS_vec(Time);
 
@@ -164,7 +164,7 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
     const double maxw = max(log_inc_wgt);
     const vec w = exp(log_inc_wgt - maxw);
     const vec norm_wgt = w / sum(w);
-    
+
     ESS_vec(tt) = (sum(norm_wgt) * sum(norm_wgt)) / sum(norm_wgt % norm_wgt);
 
     /* ====================================================== */
@@ -217,7 +217,9 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
     }
   }
   // return the history of the particles and their values
-  return Rcpp::List::create((Rcpp::Named("rho_samples") = rho_samples,
-                             Rcpp::Named("augmented_rankings") = aug_rankings,
-                             Rcpp::Named("ESS") = ESS_vec));
+  return Rcpp::List::create(
+    Rcpp::Named("rho_samples") = rho_samples,
+    Rcpp::Named("augmented_rankings") = aug_rankings,
+    Rcpp::Named("ESS") = ESS_vec
+  );
 }

--- a/src/smc_mallows_new_users_partial_alpha_fixed.cpp
+++ b/src/smc_mallows_new_users_partial_alpha_fixed.cpp
@@ -25,7 +25,8 @@ using namespace arma;
 //' @param num_new_obs Integer value for the number of new observations (complete rankings) for each time step
 //' @param aug_method A character string specifying the approach for filling in the missing data, options are "pseudolikelihood" or "random"
 //' @param alpha A numeric value of the scale parameter which is known and fixed
-//' @return a set of particles each containing a value of rho and alpha
+//' @return a set of particles each containing the values of rho and the effective sample size (ESS) at each iteration of the SMC 
+//' algorithm as well as the set of augmented rankings at the final iteration.
 //' @export
 // [[Rcpp::export]]
 Rcpp::List smc_mallows_new_users_partial_alpha_fixed(

--- a/src/smc_mallows_new_users_partial_alpha_fixed.cpp
+++ b/src/smc_mallows_new_users_partial_alpha_fixed.cpp
@@ -55,7 +55,7 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
   }
   
   /* generate vector to store ESS */
-  arma::vec ESS_vec = (Time, arma::fill::zeros);
+  rowvec ESS_vec(Time);
 
   // this is to store the augmentations of the observed rankings for each particle
   arma::cube aug_rankings(n_users, n_items, N, arma::fill::zeros); // no. users by items by particles
@@ -163,7 +163,7 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
     const arma::vec w = arma::exp(log_inc_wgt - maxw);
     const arma::vec norm_wgt = w / arma::sum(w);
     
-    ESS_vec(tt) = 1/sum(norm_wgt^2);
+    ESS_vec(tt) = (sum(norm_wgt) * sum(norm_wgt)) / sum(norm_wgt % norm_wgt);
 
     /* ====================================================== */
     /* Resample                                               */

--- a/tests/testthat/test-smc_mallows_partial_rankings.R
+++ b/tests/testthat/test-smc_mallows_partial_rankings.R
@@ -124,7 +124,7 @@ test_that("Runs with unif kernel", {
     aug_method      = "random"
   )
   expect_is(smc_unif_alpha_fixed_unif, "list")
-  expect_equal(length(smc_unif_alpha_fixed_unif), 1)
+  expect_equal(length(smc_unif_alpha_fixed_unif), 3)
   expect_equal(dim(smc_unif_alpha_fixed_unif$rho_samples), c(N, 10, 21))
   smc_unif <- smc_mallows_new_users_partial(
     R_obs           = samples,
@@ -171,7 +171,7 @@ test_that("Runs with pseudo kernel", {
     aug_method      = "pseudolikelihood"
   )
   expect_is(smc_unif_alpha_fixed_pseudo, "list")
-  expect_equal(length(smc_unif_alpha_fixed_pseudo), 1)
+  expect_equal(length(smc_unif_alpha_fixed_pseudo), 3)
   expect_equal(dim(smc_unif_alpha_fixed_pseudo$rho_samples), c(N, 10, 21))
   smc_pseudo <- smc_mallows_new_users_partial(
     R_obs           = samples,


### PR DESCRIPTION
Include a vector named `ESS_vec` (a vector of length Time) which contains the Effective Sample Size of the particles in each iteration.
Return the `aug_rankings` at end of SMC algorithm.