### PR TITLE
More work towards #199

### DIFF
--- a/src/distances.cpp
+++ b/src/distances.cpp
@@ -2,13 +2,15 @@
 #include "subset.h"
 #include "distances.h"
 
+using namespace arma;
+
 // [[Rcpp::depends(RcppArmadillo)]]
 
-double cayley_distance(const arma::vec& r1, const arma::vec& r2){
+double cayley_distance(const vec& r1, const vec& r2){
   double distance = 0;
   int n = r1.n_elem;
   double tmp1;
-  arma::vec tmp2 = r1;
+  vec tmp2 = r1;
 
   // This is a C++ translation of Rankcluster::distCayley
   for(int i = 0; i < n; ++i){
@@ -16,22 +18,22 @@ double cayley_distance(const arma::vec& r1, const arma::vec& r2){
       distance += 1;
       tmp1 = tmp2(i);
       tmp2(i) = r2(i);
-      arma::uvec inds = arma::find(tmp2 == r2(i));
+      uvec inds = arma::find(tmp2 == r2(i));
       tmp2.elem(inds).fill(tmp1);
     }
   }
   return distance;
 }
 
-double footrule_distance(const arma::vec& r1, const arma::vec& r2){
+double footrule_distance(const vec& r1, const vec& r2){
   return arma::norm(r1 - r2, 1);
 }
 
-double hamming_distance(const arma::vec& r1, const arma::vec& r2){
+double hamming_distance(const vec& r1, const vec& r2){
   return arma::sum(r1 != r2);
 }
 
-double kendall_distance(const arma::vec& r1, const arma::vec& r2){
+double kendall_distance(const vec& r1, const vec& r2){
   double distance = 0;
   int n = r1.n_elem;
 
@@ -46,16 +48,16 @@ double kendall_distance(const arma::vec& r1, const arma::vec& r2){
   return distance;
 }
 
-double spearman_distance(const arma::vec& r1, const arma::vec& r2){
+double spearman_distance(const vec& r1, const vec& r2){
   return std::pow(arma::norm(r1 - r2, 2), 2.0);
 }
 
-double ulam_distance(const arma::vec& r1, const arma::vec& r2){
+double ulam_distance(const vec& r1, const vec& r2){
 
   int N = r1.n_elem;
 
-  arma::ivec a = arma::conv_to<arma::ivec>::from(r1);
-  arma::ivec b = arma::conv_to<arma::ivec>::from(r2);
+  ivec a = arma::conv_to<ivec>::from(r1);
+  ivec b = arma::conv_to<ivec>::from(r2);
 
   int *p1 = (int*) calloc(N, sizeof (int));
   int *p2 = (int*) calloc(N, sizeof (int));
@@ -134,7 +136,7 @@ arma::vec rank_dist_vec(const arma::mat& rankings,
                         const arma::vec& obs_freq){
 
   int n = rankings.n_cols;
-  arma::vec result = arma::zeros(n);
+  vec result = arma::zeros(n);
 
   for(int i = 0; i < n; ++i){
     result(i) = get_rank_distance(rankings.col(i), rho, metric) * obs_freq(i);

--- a/src/importance_sampling.cpp
+++ b/src/importance_sampling.cpp
@@ -1,6 +1,8 @@
 #include "RcppArmadillo.h"
 #include "distances.h"
 
+using namespace arma;
+
 // via the depends attribute we tell Rcpp to create hooks for
 // RcppArmadillo so that the build process will know what to do
 //
@@ -26,53 +28,53 @@ arma::vec compute_importance_sampling_estimate(arma::vec alpha_vector, int n_ite
   int n_alphas = alpha_vector.n_elem;
 
   // The reference ranking
-  arma::vec rho = arma::regspace<arma::vec>(1, n_items);
+  vec rho = arma::regspace<vec>(1, n_items);
 
   // Vector which holds the result for all alphas
-  arma::vec logZ = arma::zeros(n_alphas);
+  vec logZ = arma::zeros(n_alphas);
 
   // Loop over the values of alpha
   for(int t = 0; t < n_alphas; ++t){
     // The current value of alpha
     double alpha = alpha_vector(t);
     // The current value of the partition function
-    arma::vec partfun(nmc);
+    vec partfun(nmc);
 
     // Loop over the Monte Carlo samples
     for(int i = 0; i < nmc; ++i){
       // Support set of the proposal distribution
-      arma::vec support = arma::regspace<arma::vec>(1, n_items);
+      vec support = arma::regspace<vec>(1, n_items);
 
       // Vector which holds the proposed ranks
-      arma::vec ranks = arma::zeros(n_items);
-      arma::vec ranks2 = arma::zeros(n_items);
+      vec ranks = arma::zeros(n_items);
+      vec ranks2 = arma::zeros(n_items);
 
       // Probability of the ranks we get
       double log_q = 0;
 
       // n_items random uniform numbers
-      arma::vec u = arma::log(arma::randu(n_items));
+      vec u = arma::log(arma::randu(n_items));
 
       // Loop over possible values given to item j in random order
-      arma::vec myind = arma::shuffle(arma::regspace(0, n_items - 1));
+      vec myind = arma::shuffle(arma::regspace(0, n_items - 1));
 
       for(int j = 0; j < n_items; ++j){
         int jj = myind(j);
         // Find the elements that have not been taken yet
-        arma::uvec inds = arma::find(support != 0);
-        arma::vec log_prob(inds.size());
+        uvec inds = arma::find(support != 0);
+        vec log_prob(inds.size());
 
         // Number of elements
         int k_max = inds.n_elem;
 
         // Reference vector
-        arma::vec r1 = inds + arma::ones(k_max);
+        vec r1 = inds + arma::ones(k_max);
         // Sampled vector
-        arma::vec r2 = rho(jj) * arma::ones(k_max);
+        vec r2 = rho(jj) * arma::ones(k_max);
         // Probability of sample. Note that this is a vector quantity.
         log_prob = - alpha / n_items * arma::pow(arma::abs(r1 - r2), (metric == "footrule") ? 1. : 2.);
         log_prob = log_prob - std::log(arma::accu(arma::exp(log_prob)));
-        arma::vec log_cpd = arma::log(arma::cumsum(arma::exp(log_prob)));
+        vec log_cpd = arma::log(arma::cumsum(arma::exp(log_prob)));
 
         // Draw a random sample
         int item_index = arma::as_scalar(arma::find(log_cpd > u(jj), 1));

--- a/src/leapandshift.cpp
+++ b/src/leapandshift.cpp
@@ -1,12 +1,13 @@
 #include "RcppArmadillo.h"
+using namespace arma;
 
 // [[Rcpp::depends(RcppArmadillo)]]
 
-void shift_step(arma::vec& rho_proposal, const arma::vec& rho,
-                const int& u, double& delta_r, arma::uvec& indices){
+void shift_step(vec& rho_proposal, const vec& rho,
+                const int& u, double& delta_r, uvec& indices){
   // Shift step:
   delta_r = rho_proposal(u - 1) - rho(u - 1);
-  indices = arma::zeros<arma::uvec>(std::abs(delta_r) + 1);
+  indices = arma::zeros<uvec>(std::abs(delta_r) + 1);
   indices[0] = u-1;
   int index;
 
@@ -26,15 +27,15 @@ void shift_step(arma::vec& rho_proposal, const arma::vec& rho,
 }
 
 
-void leap_and_shift(arma::vec& rho_proposal, arma::uvec& indices,
+void leap_and_shift(vec& rho_proposal, uvec& indices,
                     double& prob_backward, double& prob_forward,
-                    const arma::vec& rho, int leap_size, bool reduce_indices){
+                    const vec& rho, int leap_size, bool reduce_indices){
 
   // Set proposal equal to current
   rho_proposal = rho;
 
   // Help vectors
-  arma::vec support;
+  vec support;
 
   // Number of items
   int n = rho.n_elem;
@@ -87,6 +88,6 @@ void leap_and_shift(arma::vec& rho_proposal, arma::uvec& indices,
   shift_step(rho_proposal, rho, u, delta_r, indices);
 
   if(!reduce_indices){
-    indices = arma::regspace<arma::uvec>(0, n - 1);
+    indices = arma::regspace<uvec>(0, n - 1);
   }
 }

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -46,7 +46,7 @@ int sample_int(const arma::rowvec& probs){
   // Draw a uniform random number
   double u = arma::randu();
 
-  arma::uvec matches = arma::find(arma::cumsum(probs) > u, 1, "first");
+  uvec matches = arma::find(arma::cumsum(probs) > u, 1, "first");
 
   return arma::as_scalar(matches);
 }
@@ -66,13 +66,13 @@ double rtruncbeta(int shape1, int shape2, double trunc = 1) {
 }
 
 // From https://stackoverflow.com/questions/29724083
-arma::uvec arma_setdiff(arma::uvec x, arma::uvec y){
+uvec arma_setdiff(uvec x, uvec y){
 
   x = arma::unique(x);
   y = arma::unique(y);
 
   for (size_t j = 0; j < y.n_elem; j++) {
-    arma::uvec q1 = arma::find(x == y[j]);
+    uvec q1 = arma::find(x == y[j]);
     if (!q1.empty()) {
       x.shed_row(q1(0));
     }
@@ -83,9 +83,9 @@ arma::uvec arma_setdiff(arma::uvec x, arma::uvec y){
 // This is practically a signed variation of arma_setdiff. It also uses Rcpp as
 // a crutch, so future changes that work around this and only use arma objects
 // are welcome.
-arma::vec arma_setdiff_vec(arma::vec x, arma::vec y, const bool& sort_unique = false) {
+vec arma_setdiff_vec(vec x, vec y, const bool& sort_unique = false) {
   Rcpp::NumericVector x_Rcpp, y_Rcpp;
-  arma::vec x_y_diff;
+  vec x_y_diff;
   x_Rcpp = x;
   y_Rcpp = y;
   if (sort_unique) {
@@ -99,7 +99,7 @@ arma::vec arma_setdiff_vec(arma::vec x, arma::vec y, const bool& sort_unique = f
 // This is practically an Rcpp variation of arma_setdiff_arma. Future changes
 // that eliminate the use of this function in favor of arma_setdiff_vec() are
 // welcome.
-Rcpp::NumericVector Rcpp_setdiff_arma(arma::ivec x, arma::vec y) {
+Rcpp::NumericVector Rcpp_setdiff_arma(ivec x, vec y) {
   Rcpp::NumericVector x_Rcpp, y_Rcpp;
   x_Rcpp = x;
   y_Rcpp = y;
@@ -107,15 +107,15 @@ Rcpp::NumericVector Rcpp_setdiff_arma(arma::ivec x, arma::vec y) {
   return x_y_diff;
 }
 
-arma::uvec maybe_offset_indices(
-  arma::vec& x,
-  arma::uvec idx_x,
+uvec maybe_offset_indices(
+  vec& x,
+  uvec idx_x,
   const bool& quiet = true
 ) {
   // Adjust the indices of x (i.e., idx_x) depending on whether it seems to be
   // using R or C++ indices.
-  const arma::uvec& io_idx_cpp   = arma::find_nonfinite(x);
-  const arma::uvec& io_idx_input = arma::sort(idx_x);
+  const uvec& io_idx_cpp   = arma::find_nonfinite(x);
+  const uvec& io_idx_input = arma::sort(idx_x);
   std::string message = "C++ indices detected. Unchanged.";
   if (arma::any(io_idx_input - io_idx_cpp)) {
     idx_x -= 1;
@@ -127,7 +127,7 @@ arma::uvec maybe_offset_indices(
   return(idx_x);
 }
 
-sword sample_one_with_prob(arma::vec set, arma::vec probs) {
+sword sample_one_with_prob(vec set, vec probs) {
   // Used in SMC to fill in the new augmented ranking going forward.
   Rcpp::NumericVector set_Rcpp, probs_Rcpp;
   set_Rcpp = set;
@@ -136,14 +136,14 @@ sword sample_one_with_prob(arma::vec set, arma::vec probs) {
   return(chosen_one);
 }
 
-arma::uvec new_pseudo_proposal(arma::uvec items) {
+uvec new_pseudo_proposal(uvec items) {
   // Used in SMC to create new agumented ranking by using pseudo proposal. This
   // function randomly permutes the unranked items to give the order in which
   // they will be allocated.
   Rcpp::IntegerVector items_Rcpp;
   items_Rcpp = items;
-  arma::uvec order;
-  order = Rcpp::as<arma::uvec>(Rcpp::sample(items_Rcpp, items_Rcpp.length())) + 1;
+  uvec order;
+  order = Rcpp::as<uvec>(Rcpp::sample(items_Rcpp, items_Rcpp.length())) + 1;
   return(order);
 }
 
@@ -155,19 +155,19 @@ double divide_by_fact(double prob, int set_length) {
   return(prob);
 }
 
-arma::uvec permute_with_weights(arma::vec weights, int N) {
+uvec permute_with_weights(vec weights, int N) {
   // Using weights_Rcpp so that Rcpp::sample compiles. More details on
   // https://github.com/ocbe-uio/BayesMallows/issues/90#issuecomment-866614296
   Rcpp::NumericVector weights_Rcpp;
   weights_Rcpp = weights;
-  arma::uvec index;
-  index = Rcpp::as<arma::uvec>(Rcpp::sample(N, N, true, weights_Rcpp)) - 1;
+  uvec index;
+  index = Rcpp::as<uvec>(Rcpp::sample(N, N, true, weights_Rcpp)) - 1;
   return(index);
 }
 
-arma::vec arma_vec_seq(int N) {
+vec arma_vec_seq(int N) {
   // Creates an arma vector filled with {1,...,N}
   Rcpp::IntegerVector vec_Rcpp = Rcpp::seq(1, N);
-  arma::vec vec = Rcpp::as<arma::vec>(vec_Rcpp);
-  return(vec);
+  vec v = Rcpp::as<vec>(vec_Rcpp);
+  return(v);
 }

--- a/src/missing_data.cpp
+++ b/src/missing_data.cpp
@@ -3,16 +3,18 @@
 #include "distances.h"
 #include "misc.h"
 
+using namespace arma;
+
 // [[Rcpp::depends(RcppArmadillo)]]
 
-arma::vec propose_augmentation(const arma::vec& ranks, const arma::uvec& indicator){
-  arma::vec proposal = ranks;
+vec propose_augmentation(const vec& ranks, const uvec& indicator){
+  vec proposal = ranks;
   proposal(arma::find(indicator == 1)) = arma::shuffle(ranks(arma::find(indicator == 1)));
   return(proposal);
 }
 
-void initialize_missing_ranks(arma::mat& rankings, const arma::umat& missing_indicator,
-                              const arma::uvec& assessor_missing) {
+void initialize_missing_ranks(mat& rankings, const umat& missing_indicator,
+                              const uvec& assessor_missing) {
 
   int n_assessors = rankings.n_cols;
 
@@ -20,13 +22,13 @@ void initialize_missing_ranks(arma::mat& rankings, const arma::umat& missing_ind
     if(assessor_missing(i) == 0) {
       continue;
     } else {
-      arma::vec rank_vector = rankings.col(i);
-      arma::uvec present_inds = arma::find(missing_indicator.col(i) == 0);
-      arma::uvec missing_inds = arma::find(missing_indicator.col(i) == 1);
+      vec rank_vector = rankings.col(i);
+      uvec present_inds = arma::find(missing_indicator.col(i) == 0);
+      uvec missing_inds = arma::find(missing_indicator.col(i) == 1);
       // Find the available ranks and permute them
-      arma::uvec new_ranks = arma::shuffle(arma_setdiff(
-        arma::linspace<arma::uvec>(1, rank_vector.size()),
-        arma::conv_to<arma::uvec>::from(rank_vector(present_inds))
+      uvec new_ranks = arma::shuffle(arma_setdiff(
+        arma::linspace<uvec>(1, rank_vector.size()),
+        arma::conv_to<uvec>::from(rank_vector(present_inds))
       ));
 
       for(unsigned int j = 0; j < missing_inds.size(); ++j){
@@ -37,11 +39,11 @@ void initialize_missing_ranks(arma::mat& rankings, const arma::umat& missing_ind
   }
 }
 
-void update_missing_ranks(arma::mat& rankings, const arma::uvec& current_cluster_assignment,
-                          arma::vec& aug_acceptance,
-                          const arma::umat& missing_indicator,
-                          const arma::uvec& assessor_missing,
-                          const arma::vec& alpha, const arma::mat& rho,
+void update_missing_ranks(mat& rankings, const uvec& current_cluster_assignment,
+                          vec& aug_acceptance,
+                          const umat& missing_indicator,
+                          const uvec& assessor_missing,
+                          const vec& alpha, const mat& rho,
                           const std::string& metric){
 
   int n_items = rankings.n_rows;
@@ -54,7 +56,7 @@ void update_missing_ranks(arma::mat& rankings, const arma::uvec& current_cluster
     }
 
     // Sample an augmentation proposal
-    arma::vec proposal = propose_augmentation(rankings.col(i), missing_indicator.col(i));
+    vec proposal = propose_augmentation(rankings.col(i), missing_indicator.col(i));
 
     // Draw a uniform random number
     double u = std::log(arma::randu<double>());

--- a/src/mixtures.cpp
+++ b/src/mixtures.cpp
@@ -3,35 +3,36 @@
 #include "partitionfuns.h"
 #include "distances.h"
 #include "misc.h"
+using namespace arma;
 
 // [[Rcpp::depends(RcppArmadillo)]]
 
 
-void update_dist_mat(arma::mat& dist_mat, const arma::mat& rankings,
-                     const arma::mat& rho_old, const std::string& metric,
-                     const arma::vec& obs_freq){
+void update_dist_mat(mat& dist_mat, const mat& rankings,
+                     const mat& rho_old, const std::string& metric,
+                     const vec& obs_freq){
   int n_clusters = dist_mat.n_cols;
   for(int i = 0; i < n_clusters; ++i)
     dist_mat.col(i) = rank_dist_vec(rankings, rho_old.col(i), metric, obs_freq);
 }
 
-arma::uvec update_cluster_labels(
-    const arma::mat& dist_mat,
-    const arma::vec& cluster_probs,
-    const arma::vec& alpha_old,
+uvec update_cluster_labels(
+    const mat& dist_mat,
+    const vec& cluster_probs,
+    const vec& alpha_old,
     const int& n_items,
     const int& t,
     const std::string& metric,
-    const Rcpp::Nullable<arma::vec> cardinalities = R_NilValue,
-    const Rcpp::Nullable<arma::vec> logz_estimate = R_NilValue,
+    const Rcpp::Nullable<vec> cardinalities = R_NilValue,
+    const Rcpp::Nullable<vec> logz_estimate = R_NilValue,
     const bool& save_ind_clus = false
 ){
   int n_assessors = dist_mat.n_rows;
   int n_clusters = dist_mat.n_cols;
-  arma::uvec new_cluster_assignment(n_assessors);
+  uvec new_cluster_assignment(n_assessors);
 
 
-  arma::mat assignment_prob(n_assessors, n_clusters);
+  mat assignment_prob(n_assessors, n_clusters);
   for(int i = 0; i < n_clusters; ++i){
     // Compute the logarithm of the unnormalized probability
     assignment_prob.col(i) = std::log(cluster_probs(i)) -
@@ -41,7 +42,7 @@ arma::uvec update_cluster_labels(
 
   for(int i = 0; i < n_assessors; ++i){
     // Exponentiate to get unnormalized prob relative to max
-    arma::rowvec probs = arma::exp(assignment_prob.row(i) -
+    rowvec probs = arma::exp(assignment_prob.row(i) -
       arma::max(assignment_prob.row(i)));
 
     // Normalize with 1-norm
@@ -57,13 +58,13 @@ arma::uvec update_cluster_labels(
   return(new_cluster_assignment);
 }
 
-arma::vec update_cluster_probs(
-    const arma::uvec& current_cluster_assignment,
+vec update_cluster_probs(
+    const uvec& current_cluster_assignment,
     const int& n_clusters,
     const int& psi
 ){
 
-  arma::vec cluster_probs(n_clusters);
+  vec cluster_probs(n_clusters);
 
   for(int i = 0; i < n_clusters; ++i){
     // Find the parameter for this cluster and provide it to the gamma distribution
@@ -76,15 +77,15 @@ arma::vec update_cluster_probs(
 }
 
 
-arma::vec update_wcd(const arma::uvec& current_cluster_assignment,
-                     const arma::mat& dist_mat){
+vec update_wcd(const uvec& current_cluster_assignment,
+                     const mat& dist_mat){
   int n_clusters = dist_mat.n_cols;
-  arma::vec wcd(n_clusters);
+  vec wcd(n_clusters);
 
-  arma::uvec inds = arma::regspace<arma::uvec>(0, n_clusters - 1);
+  uvec inds = arma::regspace<uvec>(0, n_clusters - 1);
   for(int i = 0; i < n_clusters; ++i){
-    arma::mat dist_vec = dist_mat.submat(arma::find(current_cluster_assignment == i), inds.subvec(i, i));
-    wcd(i) = arma::sum(arma::conv_to<arma::vec>::from(dist_vec));
+    mat dist_vec = dist_mat.submat(arma::find(current_cluster_assignment == i), inds.subvec(i, i));
+    wcd(i) = arma::sum(arma::conv_to<vec>::from(dist_vec));
   }
 
   return(wcd);

--- a/src/pairwise_comparisons.cpp
+++ b/src/pairwise_comparisons.cpp
@@ -2,6 +2,8 @@
 #include "leapandshift.h"
 #include "distances.h"
 
+using namespace arma;
+
 // [[Rcpp::depends(RcppArmadillo)]]
 
 // Update shape parameters for the Bernoulli error model
@@ -10,7 +12,7 @@ void update_shape_bernoulli(
     double& shape_2,
     const double& kappa_1,
     const double& kappa_2,
-    const arma::mat& rankings,
+    const mat& rankings,
     const Rcpp::List& constraints
 ){
 
@@ -22,8 +24,8 @@ void update_shape_bernoulli(
     Rcpp::List assessor_constraints = Rcpp::as<Rcpp::List>(constraints[i]);
     for(int j = 0; j < n_items; ++j){
 
-      arma::uvec items_above = Rcpp::as<arma::uvec>(Rcpp::as<Rcpp::List>(assessor_constraints[1])[j]);
-      arma::uvec items_below = Rcpp::as<arma::uvec>(Rcpp::as<Rcpp::List>(assessor_constraints[2])[j]);
+      uvec items_above = Rcpp::as<uvec>(Rcpp::as<Rcpp::List>(assessor_constraints[1])[j]);
+      uvec items_below = Rcpp::as<uvec>(Rcpp::as<Rcpp::List>(assessor_constraints[2])[j]);
 
       for(unsigned int k = 0; k < items_above.size(); ++k){
         int g = (arma::as_scalar(rankings.col(i).row(j)) < arma::as_scalar(rankings.col(i).row(items_above(k) - 1)));
@@ -44,36 +46,36 @@ void update_shape_bernoulli(
 
 void find_pairwise_limits(int& left_limit, int& right_limit, const int& item,
                           const Rcpp::List& assessor_constraints,
-                          const arma::vec& current_ranking){
+                          const vec& current_ranking){
 
   // Find the items which are preferred to the given item
   // Items go from 1, ..., n_items, so must use [item - 1]
-  arma::uvec items_above = Rcpp::as<arma::uvec>(Rcpp::as<Rcpp::List>(assessor_constraints[1])[item - 1]);
-  arma::uvec items_below = Rcpp::as<arma::uvec>(Rcpp::as<Rcpp::List>(assessor_constraints[2])[item - 1]);
+  uvec items_above = Rcpp::as<uvec>(Rcpp::as<Rcpp::List>(assessor_constraints[1])[item - 1]);
+  uvec items_below = Rcpp::as<uvec>(Rcpp::as<Rcpp::List>(assessor_constraints[2])[item - 1]);
 
   // If there are any items above, we must find the possible rankings
   if(items_above.n_elem > 0){
     // Again subtracting 1 because of zero-first indexing
     // Find all the rankings of the items that are preferred to *item*
-    arma::vec rankings_above = current_ranking.elem(items_above - 1);
+    vec rankings_above = current_ranking.elem(items_above - 1);
     left_limit = arma::max(rankings_above);
   }
 
   // If there are any items below, we must find the possible rankings
   if(items_below.n_elem > 0){
     // Find all the rankings of the items that are disfavored to *item*
-    arma::vec rankings_below = current_ranking.elem(items_below - 1);
+    vec rankings_below = current_ranking.elem(items_below - 1);
     right_limit = arma::min(rankings_below);
   }
 
 }
 
-arma::vec propose_pairwise_augmentation(const arma::vec& ranking, const Rcpp::List& assessor_constraints){
+vec propose_pairwise_augmentation(const vec& ranking, const Rcpp::List& assessor_constraints){
 
   int n_items = ranking.n_elem;
 
   // Extract the constraints for this particular assessor
-  arma::uvec constrained_items = Rcpp::as<arma::uvec>(assessor_constraints[0]);
+  uvec constrained_items = Rcpp::as<uvec>(assessor_constraints[0]);
 
   // Sample an integer between 1 and n_items
   int item = arma::randi<int>(arma::distr_param(1, n_items));
@@ -88,11 +90,11 @@ arma::vec propose_pairwise_augmentation(const arma::vec& ranking, const Rcpp::Li
   int proposed_rank = arma::randi<int>(arma::distr_param(left_limit + 1, right_limit - 1));
 
   // Assign the proposal to the (item-1)th item
-  arma::vec proposal = ranking;
+  vec proposal = ranking;
   proposal(item - 1) = proposed_rank;
 
   double delta_r;
-  arma::uvec indices;
+  uvec indices;
 
   // Do the shift step
   shift_step(proposal, ranking, item, delta_r, indices);
@@ -100,7 +102,7 @@ arma::vec propose_pairwise_augmentation(const arma::vec& ranking, const Rcpp::Li
   return proposal;
 }
 
-arma::vec propose_swap(const arma::vec& ranking, const Rcpp::List& assessor_constraints,
+vec propose_swap(const vec& ranking, const Rcpp::List& assessor_constraints,
                        int& g_diff, const int& Lswap){
 
   int n_items = ranking.n_elem;
@@ -111,13 +113,13 @@ arma::vec propose_swap(const arma::vec& ranking, const Rcpp::List& assessor_cons
   int ind1 = arma::as_scalar(arma::find(ranking == u));
   int ind2 = arma::as_scalar(arma::find(ranking == (u + Lswap)));
 
-  arma::vec proposal = ranking;
+  vec proposal = ranking;
   proposal(ind1) = ranking(ind2);
   proposal(ind2) = ranking(ind1);
 
   // First consider the first item that was switched
-  arma::uvec items_above = Rcpp::as<arma::uvec>(Rcpp::as<Rcpp::List>(assessor_constraints[1])[ind1]);
-  arma::uvec items_below = Rcpp::as<arma::uvec>(Rcpp::as<Rcpp::List>(assessor_constraints[2])[ind1]);
+  uvec items_above = Rcpp::as<uvec>(Rcpp::as<Rcpp::List>(assessor_constraints[1])[ind1]);
+  uvec items_below = Rcpp::as<uvec>(Rcpp::as<Rcpp::List>(assessor_constraints[2])[ind1]);
 
   for(unsigned int j = 0; j < items_above.size(); ++j){
     g_diff += (proposal(items_above[j] - 1) > proposal(ind1)) - (ranking(items_above[j] - 1) > ranking(ind1));
@@ -127,8 +129,8 @@ arma::vec propose_swap(const arma::vec& ranking, const Rcpp::List& assessor_cons
   }
 
   // Now consider the second item
-  items_above = Rcpp::as<arma::uvec>(Rcpp::as<Rcpp::List>(assessor_constraints[1])[ind2]);
-  items_below = Rcpp::as<arma::uvec>(Rcpp::as<Rcpp::List>(assessor_constraints[2])[ind2]);
+  items_above = Rcpp::as<uvec>(Rcpp::as<Rcpp::List>(assessor_constraints[1])[ind2]);
+  items_below = Rcpp::as<uvec>(Rcpp::as<Rcpp::List>(assessor_constraints[2])[ind2]);
 
   for(unsigned int j = 0; j < items_above.size(); ++j){
     g_diff += (proposal(items_above[j] - 1) > proposal(ind1)) - (ranking(items_above[j] - 1) > ranking(ind1));
@@ -141,14 +143,14 @@ arma::vec propose_swap(const arma::vec& ranking, const Rcpp::List& assessor_cons
 
 
 void augment_pairwise(
-    arma::mat& rankings,
-    const arma::uvec& current_cluster_assignment,
-    const arma::vec& alpha,
+    mat& rankings,
+    const uvec& current_cluster_assignment,
+    const vec& alpha,
     const double& theta,
-    const arma::mat& rho,
+    const mat& rho,
     const std::string& metric,
     const Rcpp::List& constraints,
-    arma::vec& aug_acceptance,
+    vec& aug_acceptance,
     const bool& clustering,
     const std::string& error_model,
     const int& Lswap
@@ -159,7 +161,7 @@ void augment_pairwise(
 
   for(int i = 0; i < n_assessors; ++i){
 
-    arma::vec proposal;
+    vec proposal;
     // Summed difference over error function before and after proposal
     int g_diff = 0;
 

--- a/src/parameterupdates.cpp
+++ b/src/parameterupdates.cpp
@@ -4,29 +4,30 @@
 #include "partitionfuns.h"
 #include <cmath>
 
+using namespace arma;
 
 // [[Rcpp::depends(RcppArmadillo)]]
 
 // Initialize latent ranks as provided by rho_init, or randomly:
-arma::mat initialize_rho(Rcpp::Nullable<arma::mat> rho_init, int n_items, int n_clusters){
+mat initialize_rho(Rcpp::Nullable<mat> rho_init, int n_items, int n_clusters){
   if(rho_init.isNotNull()){
-    return arma::repmat(Rcpp::as<arma::mat>(rho_init), 1, n_clusters);
+    return arma::repmat(Rcpp::as<mat>(rho_init), 1, n_clusters);
   } else {
-    return arma::shuffle(arma::repmat(arma::regspace<arma::mat>(1, 1, n_items), 1, n_clusters));
+    return arma::shuffle(arma::repmat(arma::regspace<mat>(1, 1, n_items), 1, n_clusters));
   }
 }
 
-double update_alpha(arma::vec& alpha_acceptance,
+double update_alpha(vec& alpha_acceptance,
                   const double& alpha_old,
-                  const arma::mat& rankings,
-                  const arma::vec& obs_freq,
+                  const mat& rankings,
+                  const vec& obs_freq,
                   const int& cluster_index,
-                  const arma::vec& rho_old,
+                  const vec& rho_old,
                   const double& alpha_prop_sd,
                   const std::string& metric,
                   const double& lambda,
-                  const Rcpp::Nullable<arma::vec> cardinalities = R_NilValue,
-                  const Rcpp::Nullable<arma::vec> logz_estimate = R_NilValue,
+                  const Rcpp::Nullable<vec> cardinalities = R_NilValue,
+                  const Rcpp::Nullable<vec> logz_estimate = R_NilValue,
                   double alpha_max = 1e6) {
 
 
@@ -65,17 +66,17 @@ double update_alpha(arma::vec& alpha_acceptance,
 }
 
 
-void update_rho(arma::cube& rho, arma::vec& rho_acceptance, arma::mat& rho_old,
+void update_rho(cube& rho, vec& rho_acceptance, mat& rho_old,
                 int& rho_index, const int& cluster_index, const int& rho_thinning,
-                const double& alpha_old, const int& leap_size, const arma::mat& rankings,
+                const double& alpha_old, const int& leap_size, const mat& rankings,
                 const std::string& metric, const int& n_items, const int& t,
-                const arma::uvec& element_indices, const arma::vec& obs_freq) {
+                const uvec& element_indices, const vec& obs_freq) {
 
-  arma::vec rho_cluster = rho_old.col(cluster_index);
+  vec rho_cluster = rho_old.col(cluster_index);
 
   // Sample a rank proposal
-  arma::vec rho_proposal;
-  arma::uvec indices;
+  vec rho_proposal;
+  uvec indices;
   double prob_backward, prob_forward;
 
   leap_and_shift(rho_proposal, indices, prob_backward, prob_forward,

--- a/src/partitionfuns.cpp
+++ b/src/partitionfuns.cpp
@@ -1,6 +1,7 @@
 #include "RcppArmadillo.h"
 #include "misc.h"
 #include <cmath>
+using namespace arma;
 
 // [[Rcpp::depends(RcppArmadillo)]]
 double cayley_logz(const int& n_items, const double& alpha) {
@@ -45,7 +46,7 @@ double exact_logz(const int& n_items, const double& alpha, const std::string& me
 }
 
 // Helper to compute the importance sampling smoothed fit
-double compute_is_fit(double alpha, arma::vec fit){
+double compute_is_fit(double alpha, vec fit){
   // The partition function
   double logZ = 0;
   int n_items = fit.n_elem;
@@ -56,15 +57,15 @@ double compute_is_fit(double alpha, arma::vec fit){
   return(logZ);
 }
 
-double logz_cardinalities(const double& alpha, const int& n_items, const arma::vec& cardinalities, const std::string& metric){
+double logz_cardinalities(const double& alpha, const int& n_items, const vec& cardinalities, const std::string& metric){
   if(metric == "footrule"){
-    arma::vec distances = arma::regspace(0, 2, std::floor(std::pow(static_cast<double>(n_items), 2.) / 2));
+    vec distances = arma::regspace(0, 2, std::floor(std::pow(static_cast<double>(n_items), 2.) / 2));
     return std::log(arma::sum(cardinalities % arma::exp(-alpha * distances / n_items)));
   } else if (metric == "spearman"){
-    arma::vec distances = arma::regspace(0, 2, 2 * binomial_coefficient(n_items + 1, 3));
+    vec distances = arma::regspace(0, 2, 2 * binomial_coefficient(n_items + 1, 3));
     return std::log(arma::sum(cardinalities % arma::exp(-alpha * distances / n_items)));
   } else if (metric == "ulam"){
-    arma::vec distances = arma::regspace(0, 1, n_items - 1);
+    vec distances = arma::regspace(0, 1, n_items - 1);
     return std::log(arma::sum(cardinalities % arma::exp(-alpha * distances / n_items)));
   } else {
     Rcpp::stop("Cardinalities not implemented for the provided metric.");
@@ -85,15 +86,15 @@ double logz_cardinalities(const double& alpha, const int& n_items, const arma::v
 double log_expected_dist(const double& alpha, const int& n_items,
                          const arma::vec& cardinalities, const std::string& metric){
   if(metric == "footrule"){
-    arma::vec distances = arma::regspace(0, 2, std::floor(std::pow(static_cast<double>(n_items), 2.) / 2));
+    vec distances = arma::regspace(0, 2, std::floor(std::pow(static_cast<double>(n_items), 2.) / 2));
     return std::log(arma::sum(distances % cardinalities % arma::exp(-alpha * distances / n_items)))
       -std::log(arma::sum(cardinalities % arma::exp(-alpha * distances / n_items)));
   } else if (metric == "spearman"){
-    arma::vec distances = arma::regspace(0, 2, 2 * binomial_coefficient(n_items + 1, 3));
+    vec distances = arma::regspace(0, 2, 2 * binomial_coefficient(n_items + 1, 3));
     return std::log(arma::sum(distances % cardinalities % arma::exp(-alpha * distances / n_items)))
       -std::log(arma::sum(cardinalities % arma::exp(-alpha * distances / n_items)));
   } else if (metric == "ulam"){
-    arma::vec distances = arma::regspace(0, 1, n_items - 1);
+    vec distances = arma::regspace(0, 1, n_items - 1);
     return std::log(arma::sum(distances % cardinalities % arma::exp(-alpha * distances / n_items)))
       -std::log(arma::sum(cardinalities % arma::exp(-alpha * distances / n_items)));
   } else {
@@ -126,9 +127,9 @@ double get_partition_function(int n_items, double alpha,
 
 
   if(cardinalities.isNotNull()){
-    return logz_cardinalities(alpha, n_items, Rcpp::as<arma::vec>(cardinalities), metric);
+    return logz_cardinalities(alpha, n_items, Rcpp::as<vec>(cardinalities), metric);
   } else if(logz_estimate.isNotNull()) {
-    return compute_is_fit(alpha, Rcpp::as<arma::vec>(logz_estimate));
+    return compute_is_fit(alpha, Rcpp::as<vec>(logz_estimate));
   } else {
     return exact_logz(n_items, alpha, metric);
   }
@@ -159,14 +160,14 @@ arma::vec asymptotic_partition_function(arma::vec alpha_vector, int n_items, std
                                         int K, int n_iterations = 1000, double tol = 1e-9){
   // IPFP procedure
   // Initialize a square matrix where each row/column sums to one
-  arma::mat A = arma::ones<arma::mat>(K, K) * 1.0 / K;
+  mat A = arma::ones<mat>(K, K) * 1.0 / K;
 
   // arma::accu sums all elements of the tensor
   // the % operator computes the element-wise product
   double Z0lim = -2 * std::log(static_cast<double>(K)) - arma::accu(A % arma::log(A));
 
   // Helper matrix
-  arma::mat B(K, K);
+  mat B(K, K);
   for(int i = 0; i < K; ++i){
     for(int j = 0; j < K; ++j){
       if(metric == "footrule"){
@@ -181,13 +182,13 @@ arma::vec asymptotic_partition_function(arma::vec alpha_vector, int n_items, std
   B = B * 1.0 / K;
 
   int n_alpha = alpha_vector.n_elem;
-  arma::vec result(n_alpha);
+  vec result(n_alpha);
 
   for(int i = 0; i < n_alpha; ++i){
     double alpha = alpha_vector(i);
 
     A = arma::exp(alpha * B);
-    arma::mat A_old = A;
+    mat A_old = A;
     for(int i = 0; i < n_iterations; ++i){
       // Note: We can use 1-norm because the exponential never gets negative
       // Normalize rows

--- a/src/rmallows.cpp
+++ b/src/rmallows.cpp
@@ -2,6 +2,8 @@
 #include "leapandshift.h"
 #include "distances.h"
 
+using namespace arma;
+
 // via the depends attribute we tell Rcpp to create hooks for
 // RcppArmadillo so that the build process will know what to do
 //
@@ -46,14 +48,14 @@ arma::mat rmallows(
   int n_items = rho0.n_elem;
 
   // Declare the matrix to hold the sampled ranks
-  arma::mat rho(n_items, n_samples);
+  mat rho(n_items, n_samples);
 
   // Other variables used
   int rho_index = 0;
 
   // Vector to hold the iteration value of rho
   // Initializing it to the modal ranking
-  arma::vec rho_iter = rho0;
+  vec rho_iter = rho0;
 
   int t = 1;
   // This is the Metropolis-Hastings loop
@@ -62,8 +64,8 @@ arma::mat rmallows(
     // Check if the user has tried to stop the running
     if (t % 1000 == 0) Rcpp::checkUserInterrupt();
 
-    arma::vec rho_proposal;
-    arma::uvec indices;
+    vec rho_proposal;
+    uvec indices;
     double prob_backward, prob_forward;
 
     // Sample a proposal
@@ -72,7 +74,7 @@ arma::mat rmallows(
 
     // These distances do not work with the computational shortcut
     if ((metric == "cayley") || (metric == "ulam")) {
-      indices = arma::regspace<arma::uvec>(0, n_items - 1);
+      indices = arma::regspace<uvec>(0, n_items - 1);
     }
 
     // Compute the distances to current and proposed ranks

--- a/src/smc_calculate_backward_probability.cpp
+++ b/src/smc_calculate_backward_probability.cpp
@@ -63,18 +63,18 @@ double calculate_backward_probability(
       const uword& item_to_sample_rank = item_ordering(jj);
 
       // the rank of item in rho
-      arma::vec rho_item_rank;
+      vec rho_item_rank;
       rho_item_rank = rho(item_to_sample_rank);
 
       // next we get the sample probabilites for selecting a particular rank for
       // an item based on the current alpha and the rho rank for that item
-      const arma::vec& sample_prob_list = get_sample_probabilities(\
+      const vec& sample_prob_list = get_sample_probabilities(\
         rho_item_rank, alpha, remaining_set, metric, n_items\
       );
 
       // save the probability of selecting the specific item rank in the old
       // augmented ranking
-      const arma::uvec& sample_prob = find(remaining_set == current_ranking(jj));
+      const uvec& sample_prob = find(remaining_set == current_ranking(jj));
       backward_auxiliary_ranking_probability = \
         backward_auxiliary_ranking_probability * \
         arma::as_scalar(sample_prob_list(sample_prob));

--- a/src/smc_calculate_forward_probability.cpp
+++ b/src/smc_calculate_forward_probability.cpp
@@ -51,7 +51,7 @@ Rcpp::List calculate_forward_probability(
     // uniformly
     partial_ranking.elem(find_nonfinite(partial_ranking)) = remaining_set;
   } else {
-    arma::ivec auxiliary_ranking = Rcpp::rep(0, num_items_unranked);
+    ivec auxiliary_ranking = Rcpp::rep(0, num_items_unranked);
 
     /* ====================================================== */
     /* LOOP TO CALCULATE FORWARD AND BACKWARD PROBABILITY     */
@@ -68,12 +68,12 @@ Rcpp::List calculate_forward_probability(
       const uword item_to_sample_rank = item_ordering(jj);
 
       // the rank of item in rho
-      arma::vec rho_item_rank;
+      vec rho_item_rank;
       rho_item_rank = rho(item_to_sample_rank);
 
       // next we get the sample probabilites for selecting a particular rank for
       // an item based on the current alpha and the rho rank for that item
-      arma::vec sample_prob_list = get_sample_probabilities(\
+      vec sample_prob_list = get_sample_probabilities(\
         rho_item_rank, alpha, remaining_set, metric, n_items\
       );
 
@@ -82,7 +82,7 @@ Rcpp::List calculate_forward_probability(
 
       // save the probability of selecting the specific item rank in the old
       // augmented ranking
-      const arma::uvec sample_prob = find(remaining_set == auxiliary_ranking(jj));
+      const uvec sample_prob = find(remaining_set == auxiliary_ranking(jj));
 
       forward_auxiliary_ranking_probability = \
         forward_auxiliary_ranking_probability * \
@@ -96,7 +96,7 @@ Rcpp::List calculate_forward_probability(
     auxiliary_ranking(num_items_unranked - 1) = arma::as_scalar(remaining_set);
 
     // fit the augmented ranking within the partial rankings with NAs
-    const arma::vec& ar = arma::conv_to<arma::vec>::from(auxiliary_ranking);
+    const vec& ar = arma::conv_to<vec>::from(auxiliary_ranking);
     partial_ranking.elem(item_ordering) = ar; // ranks for items
   }
   return Rcpp::List::create(

--- a/src/smc_correction_kernel_pseudo.cpp
+++ b/src/smc_correction_kernel_pseudo.cpp
@@ -44,10 +44,10 @@ Rcpp::List correction_kernel_pseudo(
         // ranks = c(1:n_items)
 
         // find items missing from original observed ranking
-        const arma::uvec& unranked_items = find_nonfinite(observed_ranking);
+        const uvec& unranked_items = find_nonfinite(observed_ranking);
 
         // find elements missing from original observed ranking
-        arma::vec remaining_set = arma_setdiff_vec(current_ranking, observed_ranking);
+        vec remaining_set = arma_setdiff_vec(current_ranking, observed_ranking);
 
         // if we only have one missing rank, then we can
         if (remaining_set.n_elem == 1) {
@@ -56,14 +56,14 @@ Rcpp::List correction_kernel_pseudo(
             observed_ranking.elem(unranked_items) = remaining_set;
         } else {
             // create new agumented ranking by using pseudo proposal
-            arma::uvec item_ordering = new_pseudo_proposal(unranked_items);
+            uvec item_ordering = new_pseudo_proposal(unranked_items);
 
             // item ordering is the order of which items are assigned ranks in a specified order
             const uword& num_items_unranked = item_ordering.n_elem;
 
             // creating now augmented ranking whilst simultaneously calculating the backwards prob of making the same
             // augmented ranking with an alternative item ordering
-            arma::ivec auxiliary_ranking = Rcpp::rep(0, num_items_unranked);
+            ivec auxiliary_ranking = Rcpp::rep(0, num_items_unranked);
 
             //########################################################
             //## Create new augmented ranking
@@ -75,12 +75,12 @@ Rcpp::List correction_kernel_pseudo(
                 const double& item_to_sample_rank = item_ordering(jj);
 
                 // the rank of item in rho
-                arma::vec rho_item_rank;
+                vec rho_item_rank;
                 rho_item_rank = rho(item_to_sample_rank - 1);
 
                 // next we get the sample probabilites for selecting a particular rank for
                 // an item based on the current alpha and the rho rank for that item
-                const arma::vec sample_prob_list = get_sample_probabilities(\
+                const vec sample_prob_list = get_sample_probabilities(\
                     rho_item_rank, alpha, remaining_set, metric, n_items\
                 );
 
@@ -89,7 +89,7 @@ Rcpp::List correction_kernel_pseudo(
 
                 // save the probability of selecting the specific item rank in the old
                 // augmented ranking
-                const arma::uvec& sample_prob = find(remaining_set == auxiliary_ranking(jj));
+                const uvec& sample_prob = find(remaining_set == auxiliary_ranking(jj));
                 correction_prob = \
                     correction_prob * \
                     arma::as_scalar(sample_prob_list(sample_prob));
@@ -102,8 +102,8 @@ Rcpp::List correction_kernel_pseudo(
             auxiliary_ranking(num_items_unranked - 1) = arma::as_scalar(remaining_set);
 
             // fit the augmented ranking within the partial rankings with NAs
-            arma::vec ar;
-            ar = arma::conv_to<arma::vec>::from(auxiliary_ranking);
+            vec ar;
+            ar = arma::conv_to<vec>::from(auxiliary_ranking);
             observed_ranking.elem(item_ordering - 1) = ar; // ranks for items
         }
         return Rcpp::List::create(

--- a/src/smc_get_sample_probabilities.cpp
+++ b/src/smc_get_sample_probabilities.cpp
@@ -29,11 +29,11 @@ arma::vec get_sample_probabilities(
 ) {
   // define a set of probs list
   const unsigned int& num_ranks = remaining_set_ranks.n_elem;
-  arma::vec sample_prob_list = Rcpp::rep(0.0, num_ranks);
+  vec sample_prob_list = Rcpp::rep(0.0, num_ranks);
 
   // cycle through each item and calculate its specific prob
   for (uword ii = 0; ii < num_ranks; ++ii) {
-    const arma::vec item_rank = {remaining_set_ranks(ii)};
+    const vec item_rank = {remaining_set_ranks(ii)};
     const double rank_dist = get_rank_distance(rho_item_rank, item_rank, metric);
     const double sample_prob = -(alpha / n_items) * rank_dist;
     sample_prob_list(ii) = sample_prob;
@@ -41,7 +41,7 @@ arma::vec get_sample_probabilities(
 
   // normalise probs
   const double maxw = max(sample_prob_list);
-  const arma::vec w = arma::exp(sample_prob_list - maxw);
+  const vec w = arma::exp(sample_prob_list - maxw);
   sample_prob_list = w / arma::sum(w);
 
   return(sample_prob_list);

--- a/src/smc_leap_and_shift_probs.cpp
+++ b/src/smc_leap_and_shift_probs.cpp
@@ -1,6 +1,8 @@
 #include "RcppArmadillo.h"
 #include <cmath>
 
+using namespace arma;
+
 // [[Rcpp::depends(RcppArmadillo)]]
 //' @title Leap and Shift Probabilities
 //' @description Determine the new Calculates transition probabilities for proposing a new rho
@@ -37,7 +39,7 @@ Rcpp::List leap_and_shift_probs(const arma::vec rho, const int leap_size, const 
   const int rho_plus_leap = rho(u) + leap_size;
   const int low_bd = std::max(1, rho_minus_leap);
   const int max_bd = std::min(n_items, rho_plus_leap);
-  arma::ivec S = Rcpp::seq(low_bd, max_bd);
+  ivec S = Rcpp::seq(low_bd, max_bd);
   S = S.elem(arma::find(S != rho(u)));
 
   // draw a random number r from S
@@ -45,12 +47,12 @@ Rcpp::List leap_and_shift_probs(const arma::vec rho, const int leap_size, const 
   r = r - 1; // adjusting index for R correspondence
 
   // Create leap step
-  arma::vec rho_star = rho;
+  vec rho_star = rho;
   rho_star(u) = r + 1; // replace u-th entry with r
 
   // here, two elements are the same so we need to shift element and replace the repeated r with u
   const int& delta = rho_star(u) - rho(u);
-  arma::ivec rho_prime = Rcpp::rep(0, n_items);
+  ivec rho_prime = Rcpp::rep(0, n_items);
 
   // shift step
   for (int i = 0; i < n_items; ++i) {
@@ -70,12 +72,12 @@ Rcpp::List leap_and_shift_probs(const arma::vec rho, const int leap_size, const 
   const int rho_star_plus_leap = rho_star(u) + leap_size;
   const int S_star_min = std::max(1, rho_star_minus_leap);
   const int S_star_max = std::min(n_items, rho_star_plus_leap);
-  arma::ivec S_star;
+  ivec S_star;
   S_star = Rcpp::seq(S_star_min, S_star_max);
   S_star = S_star.elem(arma::find(S_star != rho_star(u)));
 
   // calculate forward and backwards probabilities
-  arma::vec forwards_prob, backwards_prob;
+  vec forwards_prob, backwards_prob;
   if (std::abs(rho_star(u) - rho(u)) == 1) {
     // p(proposed|current)
     forwards_prob = 1.0 / (n_items * S.n_elem) + 1.0 / (n_items * S_star.n_elem);

--- a/src/smc_mallows_new_item_rank.cpp
+++ b/src/smc_mallows_new_item_rank.cpp
@@ -53,17 +53,17 @@ Rcpp::List smc_mallows_new_item_rank(
   /* ====================================================== */
 
   // Generate N initial samples of rho using the uniform prior
-  arma::cube rho_samples(N, n_items, Time, arma::fill::zeros);
+  cube rho_samples(N, n_items, Time, arma::fill::zeros);
   for (uword i = 0; i < N; ++i) {
-    const arma::uvec items_sample = arma::randperm(n_items) + 1;
+    const uvec items_sample = arma::randperm(n_items) + 1;
     for (uword j = 0; j < n_items; ++j) {
       rho_samples(i, j, 0) = items_sample(j);
     }
   }
 
   /* generate alpha samples using exponential prior ------- */
-  arma::mat alpha_samples(N, Time);
-  const arma::vec alpha_samples_0 = Rcpp::rexp(N, 1);
+  mat alpha_samples(N, Time);
+  const vec alpha_samples_0 = Rcpp::rexp(N, 1);
   alpha_samples.col(0) = alpha_samples_0;
 
   /* ====================================================== */
@@ -72,14 +72,14 @@ Rcpp::List smc_mallows_new_item_rank(
   const unsigned int& num_ranks = R_obs.n_rows;
 
   // each particle has its own set of augmented rankings
-  arma::cube aug_rankings(num_ranks, n_items, N, arma::fill::zeros);
-  arma::cube prev_aug_rankings(num_ranks, n_items, N, arma::fill::zeros);
+  cube aug_rankings(num_ranks, n_items, N, arma::fill::zeros);
+  cube prev_aug_rankings(num_ranks, n_items, N, arma::fill::zeros);
 
   // augment incomplete ranks to initialise
-  const arma::ivec ranks = Rcpp::seq(1, n_items);
+  const ivec ranks = Rcpp::seq(1, n_items);
 
   // total correction prob
-  arma::vec total_correction_prob = Rcpp::rep(1.0, N);
+  vec total_correction_prob = Rcpp::rep(1.0, N);
 
   // iterate through each observed ranking and create new "corrected" augmented rankings
   for (uword ii = 0; ii < N; ++ii) {
@@ -89,39 +89,39 @@ Rcpp::List smc_mallows_new_item_rank(
     // make the correction
     for (uword jj = 0; jj < num_ranks; ++jj) {
       // fill in missing ranks based on choice of augmentation method
-      arma::vec R_obs_slice_0_row_jj = R_obs.slice(0).row(jj).t();
+      vec R_obs_slice_0_row_jj = R_obs.slice(0).row(jj).t();
       if (aug_method == "random") {
         // find elements missing from original observed ranking
         const Rcpp::NumericVector remaining_set = Rcpp_setdiff_arma(ranks, R_obs_slice_0_row_jj);
 
         // create new agumented ranking by sampling remaining ranks from set uniformly
-        arma::vec rset;
+        vec rset;
         const int& remaining_set_length = remaining_set.length();
         if (remaining_set_length == 1) {
-          rset = Rcpp::as<arma::vec>(remaining_set);
+          rset = Rcpp::as<vec>(remaining_set);
         } else {
-          rset = Rcpp::as<arma::vec>(Rcpp::sample(remaining_set, remaining_set.length()));
+          rset = Rcpp::as<vec>(Rcpp::sample(remaining_set, remaining_set.length()));
         }
-        arma::vec partial_ranking = R_obs_slice_0_row_jj;
+        vec partial_ranking = R_obs_slice_0_row_jj;
         partial_ranking.elem(arma::find_nonfinite(partial_ranking)) = rset;
 
         aug_rankings.slice(ii).row(jj) = partial_ranking.t();
         total_correction_prob(ii) = divide_by_fact(total_correction_prob(ii), remaining_set_length);
       } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
         // find items missing from original observed ranking
-        const arma::uvec& unranked_items = arma::find_nonfinite(R_obs_slice_0_row_jj);
+        const uvec& unranked_items = arma::find_nonfinite(R_obs_slice_0_row_jj);
 
         // find unallocated ranks from original observed ranking
         const Rcpp::NumericVector& remaining_set = Rcpp_setdiff_arma(ranks, R_obs_slice_0_row_jj);
 
         // randomly permute the unranked items to give the order in which they will be allocated
-        arma::uvec item_ordering;
-        item_ordering = arma::conv_to<arma::uvec>::from(arma::shuffle(unranked_items));
+        uvec item_ordering;
+        item_ordering = arma::conv_to<uvec>::from(arma::shuffle(unranked_items));
         const Rcpp::List proposal = calculate_forward_probability(\
           item_ordering, R_obs_slice_0_row_jj, remaining_set, rho_samples.slice(0).row(ii).t(),\
           alpha_samples(ii, 0), n_items, metric\
         );
-        const arma::vec& a_rank = proposal["aug_ranking"];
+        const vec& a_rank = proposal["aug_ranking"];
         const double& f_prob = proposal["forward_prob"];
         aug_rankings(arma::span(jj), arma::span::all, arma::span(ii)) = a_rank;
         total_correction_prob(ii) *= f_prob;
@@ -139,14 +139,14 @@ Rcpp::List smc_mallows_new_item_rank(
   /* ====================================================== */
 
   // incremental weight for each particle, based on new observed rankings
-  arma::vec log_inc_wgt(N, arma::fill::zeros);
+  vec log_inc_wgt(N, arma::fill::zeros);
 
   for (uword ii = 0; ii < N; ++ii) {
     // evaluate the log estimate of the partition function for a particular
     // value of alpha
 
     /* Initializing variables ------------------------------- */
-    const Rcpp::Nullable<arma::vec>& cardinalities = R_NilValue;
+    const Rcpp::Nullable<vec>& cardinalities = R_NilValue;
 
     /* Calculating log_z_alpha and log_likelihood ----------- */
     const double& log_z_alpha = get_partition_function(\
@@ -162,16 +162,16 @@ Rcpp::List smc_mallows_new_item_rank(
 
     /* normalise weights ------------------------------------ */
     const double& maxw = arma::max(log_inc_wgt);
-    const arma::vec& w = arma::exp(log_inc_wgt - maxw);
-    const arma::vec& norm_wgt = w / arma::sum(w);
+    const vec& w = arma::exp(log_inc_wgt - maxw);
+    const vec& norm_wgt = w / arma::sum(w);
 
   /* ====================================================== */
   /* Resample                                               */
   /* ====================================================== */
   /* Resample particles using multinomial resampling ------ */
-  arma::uvec index = permute_with_weights(norm_wgt, N);
+  uvec index = permute_with_weights(norm_wgt, N);
   rho_samples.slice(0) = rho_samples.slice(0).rows(index);
-  const arma::vec& asc = alpha_samples.col(0);
+  const vec& asc = alpha_samples.col(0);
   alpha_samples.col(0) = asc.elem(index);
   aug_rankings = aug_rankings.slices(index);
 
@@ -189,7 +189,7 @@ Rcpp::List smc_mallows_new_item_rank(
         alpha_prop_sd, lambda, alpha_max\
     );
     for (uword jj = 0; jj < num_ranks; ++jj) {
-      arma::vec mh_aug_result;
+      vec mh_aug_result;
       if (aug_method == "random") {
         mh_aug_result = metropolis_hastings_aug_ranking(\
           alpha_samples(ii, 0), rho_samples.slice(0).row(ii).t(), n_items,\
@@ -218,7 +218,7 @@ Rcpp::List smc_mallows_new_item_rank(
     alpha_samples.col(tt + 1) = alpha_samples.col(tt);
 
     // total correction prob
-    arma::vec particle_correction_prob = Rcpp::rep(1.0, N);
+    vec particle_correction_prob = Rcpp::rep(1.0, N);
 
     // iterate through each observed ranking and create new "corrected"
     // augmented rankings
@@ -234,7 +234,7 @@ Rcpp::List smc_mallows_new_item_rank(
             R_obs.slice(tt + 1).row(jj).t(), aug_rankings.slice(ii).row(jj).t(),\
             n_items
           );
-          const arma::vec c_rank = check_correction["ranking"];
+          const vec c_rank = check_correction["ranking"];
           const double c_prob = check_correction["correction_prob"];
           aug_rankings.slice(ii).row(jj) = c_rank.t();
           particle_correction_prob(ii) *= c_prob;
@@ -244,7 +244,7 @@ Rcpp::List smc_mallows_new_item_rank(
             rho_samples.slice(tt + 1).row(ii).t(), alpha_samples(ii, tt + 1),\
             n_items, metric
           );
-          const arma::vec c_rank = check_correction["ranking"];
+          const vec c_rank = check_correction["ranking"];
           const double c_prob = check_correction["correction_prob"];
           aug_rankings.slice(ii).row(jj) = c_rank.t();
           // # these probs are in real scale
@@ -260,7 +260,7 @@ Rcpp::List smc_mallows_new_item_rank(
     /* ====================================================== */
 
     // incremental weight for each particle, based on new observed rankings
-    arma::vec log_inc_wgt(N, arma::fill::zeros);
+    vec log_inc_wgt(N, arma::fill::zeros);
     for (uword ii = 0; ii < N; ++ii) {
       // evaluate the log estimate of the partition function for a particular
       // value of alpha
@@ -280,16 +280,16 @@ Rcpp::List smc_mallows_new_item_rank(
 
     /* normalise weights ------------------------------------ */
     double maxw = arma::max(log_inc_wgt);
-    arma::vec w = arma::exp(log_inc_wgt - maxw);
-    arma::vec norm_wgt = w / arma::sum(w);
+    vec w = arma::exp(log_inc_wgt - maxw);
+    vec norm_wgt = w / arma::sum(w);
 
     /* ====================================================== */
     /* Resample                                               */
     /* ====================================================== */
     /* Resample particles using multinomial resampling ------ */
-    arma::uvec index = permute_with_weights(norm_wgt, N);
+    uvec index = permute_with_weights(norm_wgt, N);
     rho_samples.slice(tt + 1) = rho_samples.slice(tt + 1).rows(index);
-    const arma::vec& asc = alpha_samples.col(tt + 1);
+    const vec& asc = alpha_samples.col(tt + 1);
     alpha_samples.col(tt + 1) = asc.elem(index);
     aug_rankings = aug_rankings.slices(index);
 
@@ -307,7 +307,7 @@ Rcpp::List smc_mallows_new_item_rank(
           alpha_prop_sd, lambda, alpha_max\
       );
       for (uword jj = 0; jj < num_ranks; ++jj) {
-        arma::vec mh_aug_result;
+        vec mh_aug_result;
         if (aug_method == "random") {
           mh_aug_result = metropolis_hastings_aug_ranking(\
             alpha_samples(ii, tt + 1), rho_samples.slice(tt + 1).row(ii).t(),\

--- a/src/smc_mallows_new_item_rank_alpha_fixed.cpp
+++ b/src/smc_mallows_new_item_rank_alpha_fixed.cpp
@@ -60,9 +60,9 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
   /* ====================================================== */
 
   // Generate N initial samples of rho using the uniform prior
-  arma::cube rho_samples(N, n_items, Time, arma::fill::zeros);
+  cube rho_samples(N, n_items, Time, arma::fill::zeros);
   for (uword i = 0; i < N; ++i) {
-    const arma::uvec items_sample = arma::randperm(n_items) + 1;
+    const uvec items_sample = arma::randperm(n_items) + 1;
     for (uword j = 0; j < n_items; ++j) {
       rho_samples(i, j, 0) = items_sample(j);
     }
@@ -74,14 +74,14 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
   const unsigned int num_ranks = R_obs.n_rows;
 
   // each particle has its own set of augmented rankings
-  arma::cube aug_rankings(num_ranks, n_items, N, arma::fill::zeros);
-  arma::cube prev_aug_rankings(num_ranks, n_items, N, arma::fill::zeros);
+  cube aug_rankings(num_ranks, n_items, N, arma::fill::zeros);
+  cube prev_aug_rankings(num_ranks, n_items, N, arma::fill::zeros);
 
   // augment incomplete ranks to initialise
-  const arma::ivec& ranks = Rcpp::seq(1, n_items);
+  const ivec& ranks = Rcpp::seq(1, n_items);
 
   // total correction prob
-  arma::vec total_correction_prob = Rcpp::rep(1.0, N);
+  vec total_correction_prob = Rcpp::rep(1.0, N);
 
   // iterate through each observed ranking and create new "corrected" augmented rankings
   for (uword ii = 0; ii < N; ++ii) {
@@ -89,20 +89,20 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
     prev_aug_rankings.slice(ii) = aug_rankings.slice(ii);
 
     for (uword jj = 0; jj < num_ranks; ++jj) {
-      const arma::vec& R_obs_slice_0_row_jj = R_obs.slice(0).row(jj).t();
+      const vec& R_obs_slice_0_row_jj = R_obs.slice(0).row(jj).t();
       if (aug_method == "random") {
         // find elements missing from original observed ranking
-        arma::vec partial_ranking = R_obs_slice_0_row_jj;
+        vec partial_ranking = R_obs_slice_0_row_jj;
 
         const Rcpp::NumericVector& remaining_set = Rcpp_setdiff_arma(ranks, partial_ranking);
 
         // create new agumented ranking by sampling remaining ranks from set uniformly
-        arma::vec rset;
+        vec rset;
         const int& remaining_set_length = remaining_set.length();
         if (remaining_set_length == 1) {
-          rset = Rcpp::as<arma::vec>(remaining_set);
+          rset = Rcpp::as<vec>(remaining_set);
         } else {
-          rset = Rcpp::as<arma::vec>(Rcpp::sample(remaining_set, remaining_set.length()));
+          rset = Rcpp::as<vec>(Rcpp::sample(remaining_set, remaining_set.length()));
         }
         partial_ranking.elem(arma::find_nonfinite(partial_ranking)) = rset;
 
@@ -112,19 +112,19 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
         total_correction_prob(ii) = divide_by_fact(total_correction_prob(ii), remaining_set_length);
       } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
         // find items missing from original observed ranking
-        const arma::uvec& unranked_items = arma::find_nonfinite(R_obs_slice_0_row_jj);
+        const uvec& unranked_items = arma::find_nonfinite(R_obs_slice_0_row_jj);
 
         // find unallocated ranks from original observed ranking
         const Rcpp::NumericVector& remaining_set = Rcpp_setdiff_arma(ranks, R_obs_slice_0_row_jj);
 
         // randomly permute the unranked items to give the order in which they will be allocated
-        arma::uvec item_ordering;
-        item_ordering = arma::conv_to<arma::uvec>::from(arma::shuffle(unranked_items));
+        uvec item_ordering;
+        item_ordering = arma::conv_to<uvec>::from(arma::shuffle(unranked_items));
         const Rcpp::List proposal = calculate_forward_probability(\
           item_ordering, R_obs_slice_0_row_jj, remaining_set, rho_samples.slice(0).row(ii).t(),\
           alpha, n_items, metric\
         );
-        const arma::vec& a_rank = proposal["aug_ranking"];
+        const vec& a_rank = proposal["aug_ranking"];
         const double& f_prob = proposal["forward_prob"];
         aug_rankings(arma::span(jj), arma::span::all, arma::span(ii)) = a_rank;
         total_correction_prob(ii) *= f_prob;
@@ -144,14 +144,14 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
   /* ====================================================== */
 
   // incremental weight for each particle, based on new observed rankings
-  arma::vec log_inc_wgt(N, arma::fill::zeros);
+  vec log_inc_wgt(N, arma::fill::zeros);
 
   for (uword ii = 0; ii < N; ++ii) {
     // evaluate the log estimate of the partition function for a particular
     // value of alpha
 
     /* Initializing variables ------------------------------- */
-    const Rcpp::Nullable<arma::vec> cardinalities = R_NilValue;
+    const Rcpp::Nullable<vec> cardinalities = R_NilValue;
 
     /* Calculating log_z_alpha and log_likelihood ----------- */
     double log_z_alpha = get_partition_function(\
@@ -167,14 +167,14 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
 
   /* normalise weights ------------------------------------ */
   double maxw = arma::max(log_inc_wgt);
-  arma::vec w = arma::exp(log_inc_wgt - maxw);
-  arma::vec norm_wgt = w / arma::sum(w);
+  vec w = arma::exp(log_inc_wgt - maxw);
+  vec norm_wgt = w / arma::sum(w);
 
   /* ====================================================== */
   /* Resample                                               */
   /* ====================================================== */
   /* Resample particles using multinomial resampling ------ */
-  arma::uvec index = permute_with_weights(norm_wgt, N);
+  uvec index = permute_with_weights(norm_wgt, N);
   rho_samples.slice(0) = rho_samples.slice(0).rows(index);
   aug_rankings = aug_rankings.slices(index);
 
@@ -187,7 +187,7 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
       rho_samples.slice(0).row(ii).t(), leap_size\
     ).t();
     for (uword jj = 0; jj < num_ranks; ++jj) {
-      arma::vec mh_aug_result;
+      vec mh_aug_result;
       if (aug_method == "random") {
         mh_aug_result = metropolis_hastings_aug_ranking(\
           alpha, rho_samples.slice(0).row(ii).t(), n_items,\
@@ -215,7 +215,7 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
     rho_samples.slice(tt + 1) = rho_samples.slice(tt);
 
     // total correction prob
-    arma::vec total_correction_prob = Rcpp::rep(1.0, N);
+    vec total_correction_prob = Rcpp::rep(1.0, N);
 
     // iterate through each observed ranking and create new "corrected"
     // augmented rankings
@@ -230,7 +230,7 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
             R_obs.slice(tt + 1).row(jj).t(), aug_rankings.slice(ii).row(jj).t(),\
             n_items
           );
-          arma::vec c_rank = check_correction["ranking"];
+          vec c_rank = check_correction["ranking"];
           double c_prob = check_correction["correction_prob"];
           aug_rankings.slice(ii).row(jj) = c_rank.t();
           total_correction_prob(ii) *= c_prob;
@@ -239,7 +239,7 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
             aug_rankings.slice(ii).row(jj).t(), R_obs.slice(tt + 1).row(jj).t(),\
             rho_samples.slice(tt + 1).row(ii).t(), alpha, n_items, metric\
           );
-          arma::vec c_rank = check_correction["ranking"];
+          vec c_rank = check_correction["ranking"];
           double c_prob = check_correction["correction_prob"];
           aug_rankings.slice(ii).row(jj) = c_rank.t();
           // # these probs are in real scale
@@ -255,7 +255,7 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
     /* ====================================================== */
 
     // incremental weight for each particle, based on new observed rankings
-    arma::vec log_inc_wgt(N, arma::fill::zeros);
+    vec log_inc_wgt(N, arma::fill::zeros);
     for (uword ii = 0; ii < N; ++ii) {
       // evaluate the log estimate of the partition function for a particular
       // value of alpha
@@ -275,14 +275,14 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
 
     /* normalise weights ------------------------------------ */
     double maxw = arma::max(log_inc_wgt);
-    arma::vec w = arma::exp(log_inc_wgt - maxw);
-    arma::vec norm_wgt = w / arma::sum(w);
+    vec w = arma::exp(log_inc_wgt - maxw);
+    vec norm_wgt = w / arma::sum(w);
 
     /* ====================================================== */
     /* Resample                                               */
     /* ====================================================== */
     /* Resample particles using multinomial resampling ------ */
-    arma::uvec index = permute_with_weights(norm_wgt, N);
+    uvec index = permute_with_weights(norm_wgt, N);
     rho_samples.slice(tt + 1) = rho_samples.slice(tt + 1).rows(index);
 
     /* ====================================================== */
@@ -294,7 +294,7 @@ Rcpp::List smc_mallows_new_item_rank_alpha_fixed(
         rho_samples.slice(tt + 1).row(ii).t(), leap_size\
       ).t();
       for (uword jj = 0; jj < num_ranks; ++jj) {
-        arma::vec mh_aug_result;
+        vec mh_aug_result;
         if (aug_method == "random") {
           mh_aug_result = metropolis_hastings_aug_ranking(\
             alpha, rho_samples.slice(tt + 1).row(ii).t(),\

--- a/src/smc_mallows_new_users_complete.cpp
+++ b/src/smc_mallows_new_users_complete.cpp
@@ -76,21 +76,21 @@ Rcpp::List smc_mallows_new_users_complete(
   }
 
   /* generate rho samples using uniform prior ------------- */
-  arma::cube rho_samples(N, n_items, (n_users + Time + 1), arma::fill::zeros);
+  cube rho_samples(N, n_items, (n_users + Time + 1), arma::fill::zeros);
   for (int i = 0; i < N; ++i) {
-    const arma::uvec items_sample = arma::randperm(n_items) + 1;
+    const uvec items_sample = arma::randperm(n_items) + 1;
     for (int j = 0; j < n_items; ++j) {
       rho_samples(i, j, 0) = items_sample(j);
     }
   }
 
   /* generate alpha samples using exponential prior ------- */
-  arma::mat alpha_samples(N, (n_users + Time + 1));
-  const arma::vec alpha_samples_0 = Rcpp::rexp(N, 1);
+  mat alpha_samples(N, (n_users + Time + 1));
+  const vec alpha_samples_0 = Rcpp::rexp(N, 1);
   alpha_samples.col(0) = alpha_samples_0;
 
   /* generate vector to store ESS */
-  arma::rowvec ESS_vec(Time);
+  rowvec ESS_vec(Time);
 
   /* ====================================================== */
   /* New user situation                                     */
@@ -109,8 +109,8 @@ Rcpp::List smc_mallows_new_users_complete(
     // create two ranking dataset to use for the reweight and move stages of the
     // algorithm
     const int row_start = num_obs - num_new_obs;
-    arma::mat new_observed_rankings(num_obs, R_obs.n_cols);
-    arma::mat all_observed_rankings;
+    mat new_observed_rankings(num_obs, R_obs.n_cols);
+    mat all_observed_rankings;
     new_observed_rankings = R_obs.submat(row_start, 0, num_obs - 1, R_obs.n_cols - 1);
     all_observed_rankings = R_obs.submat(0, 0, num_obs - 1, R_obs.n_cols - 1);
 
@@ -124,16 +124,16 @@ Rcpp::List smc_mallows_new_users_complete(
 
     // calculate incremental weight for each particle, based on
     // new observed rankings
-    arma::vec log_inc_wgt(N, arma::fill::zeros);
+    vec log_inc_wgt(N, arma::fill::zeros);
 
     for (int ii = 0; ii < N; ++ii) {
       // evaluate the log estimate of the partition function for a particular
       // value of alpha
 
       /* Initializing variables ------------------------------- */
-      const Rcpp::Nullable<arma::vec>& cardinalities = R_NilValue;
+      const Rcpp::Nullable<vec>& cardinalities = R_NilValue;
       const double& alpha_samples_ii = alpha_samples(ii, tt + 1);
-      const arma::rowvec rho_samples_ii = \
+      const rowvec rho_samples_ii = \
         rho_samples(arma::span(ii), arma::span::all, arma::span(tt + 1));
 
       /* Calculating log_z_alpha and log_likelihood ----------- */
@@ -150,8 +150,8 @@ Rcpp::List smc_mallows_new_users_complete(
 
     /* normalise weights ------------------------------------ */
     const double& maxw = arma::max(log_inc_wgt);
-    const arma::vec& w = arma::exp(log_inc_wgt - maxw);
-    const arma::vec norm_wgt = w / arma::sum(w);
+    const vec& w = arma::exp(log_inc_wgt - maxw);
+    const vec norm_wgt = w / arma::sum(w);
 
     /* store ESS = sum(w)^2/sum(w^2) */
     ESS_vec(tt) = (arma::sum(norm_wgt) * arma::sum(norm_wgt)) / arma::sum(norm_wgt % norm_wgt);
@@ -162,12 +162,12 @@ Rcpp::List smc_mallows_new_users_complete(
     /* ====================================================== */
 
     /* Resample particles using multinomial resampling ------ */
-    arma::uvec index = permute_with_weights(norm_wgt, N);
-    arma::uvec tt_vec;
+    uvec index = permute_with_weights(norm_wgt, N);
+    uvec tt_vec;
     tt_vec = tt;
 
     /* Replacing tt + 1 slice on rho_samples ---------------- */
-    arma::mat& rho_samples_slice_11p1 = rho_samples.slice(tt + 1);
+    mat& rho_samples_slice_11p1 = rho_samples.slice(tt + 1);
     rho_samples_slice_11p1 = rho_samples_slice_11p1.rows(index);
     rho_samples.slice(tt + 1) = rho_samples_slice_11p1;
 
@@ -182,7 +182,7 @@ Rcpp::List smc_mallows_new_users_complete(
         // move each particle containing sample of rho and alpha by using
         // the MCMC kernels
         const double& as = alpha_samples(ii, tt + 1);
-        const arma::rowvec& rs = \
+        const rowvec& rs = \
           rho_samples(arma::span(ii), arma::span::all, arma::span(tt + 1));
         rho_samples(arma::span(ii), arma::span::all, arma::span(tt + 1)) =\
           metropolis_hastings_rho(\

--- a/src/smc_mallows_new_users_partial.cpp
+++ b/src/smc_mallows_new_users_partial.cpp
@@ -56,21 +56,21 @@ Rcpp::List smc_mallows_new_users_partial(
   const int& n_users = R_obs.n_rows; // this is total- number of users
 
   /* generate rho samples using uniform prior ------------- */
-  arma::cube rho_samples(N, n_items, Time + 1, arma::fill::zeros);
+  cube rho_samples(N, n_items, Time + 1, arma::fill::zeros);
   for (uword i = 0; i < N; ++i) {
-    arma::uvec items_sample = arma::randperm(n_items) + 1;
+    uvec items_sample = arma::randperm(n_items) + 1;
     for (uword j = 0; j < n_items; ++j) {
       rho_samples(i, j, 0) = items_sample(j);
     }
   }
 
   /* generate alpha samples using exponential prior ------- */
-  arma::mat alpha_samples(N, Time + 1);
-  const arma::vec& alpha_samples_0 = Rcpp::rexp(N, 1);
+  mat alpha_samples(N, Time + 1);
+  const vec& alpha_samples_0 = Rcpp::rexp(N, 1);
   alpha_samples.col(0) = alpha_samples_0;
 
   // this is to store the augmentations of the observed rankings for each particle
-  arma::cube aug_rankings(n_users, n_items, N, arma::fill::zeros); // no. users by items by particles
+  cube aug_rankings(n_users, n_items, N, arma::fill::zeros); // no. users by items by particles
 
   /* ====================================================== */
   /* New user situation                                     */
@@ -91,21 +91,21 @@ Rcpp::List smc_mallows_new_users_partial(
 
     // calculate incremental weight and augmentation prob for each particle,
     // based on new observed rankings
-    arma::vec log_inc_wgt(N, arma::fill::zeros);
+    vec log_inc_wgt(N, arma::fill::zeros);
 
     /* ====================================================== */
     /* Augment partial rankings                               */
     /* ====================================================== */
 
-    const arma::ivec ranks = Rcpp::seq(1, n_items);
-    arma::vec aug_prob = Rcpp::rep(1.0, N);
+    const ivec ranks = Rcpp::seq(1, n_items);
+    vec aug_prob = Rcpp::rep(1.0, N);
 
     for (uword ii = 0; ii < N; ++ii) {
       for (uword jj = num_obs - num_new_obs; jj < num_obs; ++jj) {
-        arma::vec partial_ranking = R_obs.row(jj).t();
+        vec partial_ranking = R_obs.row(jj).t();
 
         // find items missing from original observed ranking
-        arma::uvec unranked_items = find_nonfinite(partial_ranking);
+        uvec unranked_items = find_nonfinite(partial_ranking);
 
         // find ranks missing from ranking
         const Rcpp::NumericVector missing_ranks = Rcpp::sort_unique(Rcpp_setdiff_arma(ranks, partial_ranking));
@@ -115,9 +115,9 @@ Rcpp::List smc_mallows_new_users_partial(
 
           // create new agumented ranking by sampling remaining ranks from set uniformly
           if (missing_ranks.length() == 1) {
-            partial_ranking.elem(arma::find_nonfinite(partial_ranking)) = Rcpp::as<arma::vec>(missing_ranks);
+            partial_ranking.elem(arma::find_nonfinite(partial_ranking)) = Rcpp::as<vec>(missing_ranks);
           } else {
-            partial_ranking.elem(arma::find_nonfinite(partial_ranking)) = Rcpp::as<arma::vec>(Rcpp::sample(missing_ranks, missing_ranks.length()));
+            partial_ranking.elem(arma::find_nonfinite(partial_ranking)) = Rcpp::as<vec>(Rcpp::sample(missing_ranks, missing_ranks.length()));
           }
 
           aug_rankings(arma::span(jj), arma::span::all, arma::span(ii)) = partial_ranking;
@@ -126,14 +126,14 @@ Rcpp::List smc_mallows_new_users_partial(
         } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
 
           // randomly permute the unranked items to give the order in which they will be allocated
-          arma::uvec item_ordering;
-          item_ordering = arma::conv_to<arma::uvec>::from(arma::shuffle(unranked_items));
-          const arma::rowvec rho_s = rho_samples(arma::span(ii), arma::span::all, arma::span(tt + 1));
+          uvec item_ordering;
+          item_ordering = arma::conv_to<uvec>::from(arma::shuffle(unranked_items));
+          const rowvec rho_s = rho_samples(arma::span(ii), arma::span::all, arma::span(tt + 1));
           const Rcpp::List proposal = calculate_forward_probability(\
             item_ordering, partial_ranking, missing_ranks, rho_s.t(),\
             alpha_samples(ii, tt + 1), n_items, metric\
           );
-          const arma::vec& a_rank = proposal["aug_ranking"];
+          const vec& a_rank = proposal["aug_ranking"];
           const double& f_prob = proposal["forward_prob"];
           aug_rankings(arma::span(jj), arma::span::all, arma::span(ii)) = a_rank;
           aug_prob(ii) = aug_prob(ii) * f_prob;
@@ -152,9 +152,9 @@ Rcpp::List smc_mallows_new_users_partial(
       // value of alpha
 
       /* Initializing variables ------------------------------- */
-      const Rcpp::Nullable<arma::vec>& cardinalities = R_NilValue;
+      const Rcpp::Nullable<vec>& cardinalities = R_NilValue;
       double alpha_samples_ii = alpha_samples(ii, tt + 1);
-      arma::rowvec rho_samples_ii = \
+      rowvec rho_samples_ii = \
         rho_samples(arma::span(ii), arma::span::all, arma::span(tt + 1));
 
       /* Calculating log_z_alpha and log_likelihood ----------- */
@@ -163,7 +163,7 @@ Rcpp::List smc_mallows_new_users_partial(
         n_items, alpha_samples_ii, cardinalities, logz_estimate, metric\
       );
 
-      arma::mat new_observed_rankings;
+      mat new_observed_rankings;
       new_observed_rankings = aug_rankings(arma::span(num_obs - num_new_obs, num_obs - 1), arma::span::all, arma::span(ii));
       log_likelihood = get_mallows_loglik(\
         alpha_samples_ii, rho_samples_ii.t(), n_items, new_observed_rankings,\
@@ -174,26 +174,26 @@ Rcpp::List smc_mallows_new_users_partial(
 
     /* normalise weights ------------------------------------ */
     double maxw = arma::max(log_inc_wgt);
-    arma::vec w = arma::exp(log_inc_wgt - maxw);
-    arma::vec norm_wgt = w / arma::sum(w);
+    vec w = arma::exp(log_inc_wgt - maxw);
+    vec norm_wgt = w / arma::sum(w);
 
     /* ====================================================== */
     /* Resample                                               */
     /* ====================================================== */
 
     /* Resample particles using multinomial resampling ------ */
-    arma::uvec index = permute_with_weights(norm_wgt, N);
-    arma::uvec tt_vec;
+    uvec index = permute_with_weights(norm_wgt, N);
+    uvec tt_vec;
     tt_vec = tt;
 
     /* Replacing tt + 1 slice on rho_samples ---------------- */
-    arma::mat rho_samples_slice_11p1 = rho_samples.slice(tt + 1);
+    mat rho_samples_slice_11p1 = rho_samples.slice(tt + 1);
     rho_samples_slice_11p1 = rho_samples_slice_11p1.rows(index);
     rho_samples.slice(tt + 1) = rho_samples_slice_11p1;
 
     /* Replacing tt + 1 column on alpha_samples ------------- */
     alpha_samples.col(tt + 1) =  alpha_samples.submat(index, tt_vec + 1);
-    arma::cube aug_rankings_index = aug_rankings.slices(index);
+    cube aug_rankings_index = aug_rankings.slices(index);
     aug_rankings.rows(0, num_obs - 1) = aug_rankings_index(arma::span(0, num_obs - 1), arma::span::all, arma::span::all);
 
     /* ====================================================== */
@@ -201,10 +201,10 @@ Rcpp::List smc_mallows_new_users_partial(
     /* ====================================================== */
     for (uword ii = 0; ii < N; ++ii) {
       double as = alpha_samples(ii, tt + 1);
-      arma::mat all_observed_rankings;
+      mat all_observed_rankings;
       all_observed_rankings = aug_rankings(arma::span(0, num_obs - 1), arma::span::all, arma::span(ii));
-      arma::mat rs_slice = rho_samples.slice(tt + 1);
-      arma::rowvec rs = rs_slice.row(ii);
+      mat rs_slice = rho_samples.slice(tt + 1);
+      rowvec rs = rs_slice.row(ii);
       // move each particle containing sample of rho and alpha by using
       // the MCMC kernels
       rho_samples(arma::span(ii), arma::span::all, arma::span(tt + 1)) =\
@@ -216,9 +216,9 @@ Rcpp::List smc_mallows_new_users_partial(
         alpha_prop_sd, lambda, alpha_max\
       );
       for (uword jj = 0; jj < num_obs; ++jj) {
-        arma::rowvec ar;
+        rowvec ar;
         ar = aug_rankings(arma::span(jj), arma::span::all, arma::span(ii));
-        arma::vec mh_aug_result;
+        vec mh_aug_result;
         if (aug_method == "random") {
           mh_aug_result = metropolis_hastings_aug_ranking(as, rs.t(), n_items, R_obs.row(jj).t(), ar.t(), metric);
         } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {

--- a/src/smc_mallows_new_users_partial_alpha_fixed.cpp
+++ b/src/smc_mallows_new_users_partial_alpha_fixed.cpp
@@ -48,16 +48,16 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
   const int& n_users = R_obs.n_rows; // this is total- number of users
 
   // generate rho samples using uniform prior
-  arma::cube rho_samples(N, n_items, Time + 1, arma::fill::zeros);
+  cube rho_samples(N, n_items, Time + 1, arma::fill::zeros);
   for (uword i = 0; i < N; ++i) {
-    const arma::uvec items_sample = arma::randperm(n_items) + 1;
+    const uvec items_sample = arma::randperm(n_items) + 1;
     for (uword j = 0; j < n_items; ++j) {
       rho_samples(i, j, 0) = items_sample(j);
     }
   }
 
   // this is to store the augmentations of the observed rankings for each particle
-  arma::cube aug_rankings(n_users, n_items, N, arma::fill::zeros); // no. users by items by particles
+  cube aug_rankings(n_users, n_items, N, arma::fill::zeros); // no. users by items by particles
 
   /* ====================================================== */
   /* New user situation                                     */
@@ -82,21 +82,21 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
 
     // calculate incremental weight and augmentation prob for each particle,
     // based on new observed rankings
-    arma::vec log_inc_wgt(N, arma::fill::zeros);
+    vec log_inc_wgt(N, arma::fill::zeros);
 
     /* ====================================================== */
     /* Augment partial rankings                               */
     /* ====================================================== */
 
-    const arma::ivec ranks = Rcpp::seq(1, n_items);
-    arma::vec aug_prob = Rcpp::rep(1.0, N);
+    const ivec ranks = Rcpp::seq(1, n_items);
+    vec aug_prob = Rcpp::rep(1.0, N);
 
     for (uword ii = 0; ii < N; ++ii) {
       for (uword jj = num_obs - num_new_obs; jj < num_obs; ++jj) {
-        arma::vec partial_ranking = R_obs.row(jj).t();
+        vec partial_ranking = R_obs.row(jj).t();
 
         // find items missing from original observed ranking
-        const arma::uvec& unranked_items = find_nonfinite(partial_ranking);
+        const uvec& unranked_items = find_nonfinite(partial_ranking);
 
         // find ranks missing from ranking
         const Rcpp::NumericVector& missing_ranks = Rcpp_setdiff_arma(ranks, partial_ranking);
@@ -105,23 +105,23 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
         if (aug_method == "random") {
         // create new agumented ranking by sampling remaining ranks from set uniformly
           if (missing_ranks.length() == 1) {
-            partial_ranking.elem(arma::find_nonfinite(partial_ranking)) = Rcpp::as<arma::vec>(missing_ranks);
+            partial_ranking.elem(arma::find_nonfinite(partial_ranking)) = Rcpp::as<vec>(missing_ranks);
           } else {
-            partial_ranking.elem(arma::find_nonfinite(partial_ranking)) = Rcpp::as<arma::vec>(Rcpp::sample(missing_ranks, missing_ranks.length()));
+            partial_ranking.elem(arma::find_nonfinite(partial_ranking)) = Rcpp::as<vec>(Rcpp::sample(missing_ranks, missing_ranks.length()));
           }
 
           aug_rankings(arma::span(jj), arma::span::all, arma::span(ii)) = partial_ranking;
           aug_prob(ii) = divide_by_fact(aug_prob(ii), missing_ranks.length());
         } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
           // randomly permute the unranked items to give the order in which they will be allocated
-          arma::uvec item_ordering;
-          item_ordering = arma::conv_to<arma::uvec>::from(arma::shuffle(unranked_items));
-          const arma::rowvec& rho_s = rho_samples(arma::span(ii), arma::span::all, arma::span(tt + 1));
+          uvec item_ordering;
+          item_ordering = arma::conv_to<uvec>::from(arma::shuffle(unranked_items));
+          const rowvec& rho_s = rho_samples(arma::span(ii), arma::span::all, arma::span(tt + 1));
           const Rcpp::List& proposal = calculate_forward_probability(\
             item_ordering, partial_ranking, missing_ranks, rho_s.t(),\
             alpha, n_items, metric\
           );
-          const arma::vec& a_rank = proposal["aug_ranking"];
+          const vec& a_rank = proposal["aug_ranking"];
           const double& f_prob = proposal["forward_prob"];
           aug_rankings(arma::span(jj), arma::span::all, arma::span(ii)) = a_rank;
           aug_prob(ii) = aug_prob(ii) * f_prob;
@@ -140,8 +140,8 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
       // value of alpha
 
       /* Initializing variables ------------------------------- */
-      const Rcpp::Nullable<arma::vec> cardinalities = R_NilValue;
-      const arma::rowvec rho_samples_ii = \
+      const Rcpp::Nullable<vec> cardinalities = R_NilValue;
+      const rowvec rho_samples_ii = \
         rho_samples(arma::span(ii), arma::span::all, arma::span(tt + 1));
 
       /* Calculating log_z_alpha and log_likelihood ----------- */
@@ -149,7 +149,7 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
         n_items, alpha, cardinalities, logz_estimate, metric\
       );
 
-      arma::mat new_observed_rankings;
+      mat new_observed_rankings;
       new_observed_rankings = aug_rankings(arma::span(num_obs - num_new_obs, num_obs - 1), arma::span::all, arma::span(ii));
       double log_likelihood = get_mallows_loglik(\
         alpha, rho_samples_ii.t(), n_items, new_observed_rankings, metric\
@@ -159,35 +159,35 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
 
     /* normalise weights ------------------------------------ */
     const double maxw = arma::max(log_inc_wgt);
-    const arma::vec w = arma::exp(log_inc_wgt - maxw);
-    const arma::vec norm_wgt = w / arma::sum(w);
+    const vec w = arma::exp(log_inc_wgt - maxw);
+    const vec norm_wgt = w / arma::sum(w);
 
     /* ====================================================== */
     /* Resample                                               */
     /* ====================================================== */
 
     /* Resample particles using multinomial resampling ------ */
-    arma::uvec index = permute_with_weights(norm_wgt, N);
-    arma::uvec tt_vec;
+    uvec index = permute_with_weights(norm_wgt, N);
+    uvec tt_vec;
     tt_vec = tt;
 
     /* Replacing tt + 1 slice on rho_samples ---------------- */
-    arma::mat rho_samples_slice_11p1 = rho_samples.slice(tt + 1);
+    mat rho_samples_slice_11p1 = rho_samples.slice(tt + 1);
     rho_samples_slice_11p1 = rho_samples_slice_11p1.rows(index);
     rho_samples.slice(tt + 1) = rho_samples_slice_11p1;
 
     /* Replacing tt + 1 column on alpha_samples ------------- */
-    const arma::cube& aug_rankings_index = aug_rankings.slices(index);
+    const cube& aug_rankings_index = aug_rankings.slices(index);
     aug_rankings.rows(0, num_obs - 1) = aug_rankings_index(arma::span(0, num_obs - 1), arma::span::all, arma::span::all);
 
     /* ====================================================== */
     /* Move step                                              */
     /* ====================================================== */
     for (uword ii = 0; ii < N; ++ii) {
-      arma::mat all_observed_rankings;
+      mat all_observed_rankings;
       all_observed_rankings = aug_rankings(arma::span(0, num_obs - 1), arma::span::all, arma::span(ii));
-      const arma::mat& rs_slice = rho_samples.slice(tt + 1);
-      const arma::rowvec& rs = rs_slice.row(ii);
+      const mat& rs_slice = rho_samples.slice(tt + 1);
+      const rowvec& rs = rs_slice.row(ii);
       // move each particle containing sample of rho and alpha by using
       // the MCMC kernels
       rho_samples(arma::span(ii), arma::span::all, arma::span(tt + 1)) =\
@@ -195,9 +195,9 @@ Rcpp::List smc_mallows_new_users_partial_alpha_fixed(
           alpha, n_items, all_observed_rankings, metric, rs.t(), leap_size\
         );
       for (uword jj = 0; jj < num_obs; ++jj) {
-        arma::rowvec ar;
+        rowvec ar;
         ar = aug_rankings(arma::span(jj), arma::span::all, arma::span(ii));
-        arma::vec mh_aug_result;
+        vec mh_aug_result;
         if (aug_method == "random") {
           mh_aug_result = metropolis_hastings_aug_ranking(\
           alpha, rs.t(), n_items, R_obs.row(jj).t(), ar.t(), metric\

--- a/src/smc_metropolis_hastings_alpha.cpp
+++ b/src/smc_metropolis_hastings_alpha.cpp
@@ -2,6 +2,8 @@
 #include "smc.h"
 #include "partitionfuns.h"
 
+using namespace arma;
+
 // [[Rcpp::depends(RcppArmadillo)]]
 //' @title Metropolis-Hastings Alpha
 //' @description Function to perform Metropolis-Hastings for new rho under
@@ -58,7 +60,7 @@ double metropolis_hastings_alpha(
 
   // evaluate the log estimate of the partition function for a particular
   // value of alpha
-  const Rcpp::Nullable<arma::vec>& cardinalities = R_NilValue;
+  const Rcpp::Nullable<vec>& cardinalities = R_NilValue;
   const double logz_alpha = get_partition_function(n_items, alpha, cardinalities, logz_estimate, metric);
   const double logz_alpha_prime = get_partition_function(n_items, alpha_prime, cardinalities, logz_estimate, metric);
 

--- a/src/smc_metropolis_hastings_aug_ranking.cpp
+++ b/src/smc_metropolis_hastings_aug_ranking.cpp
@@ -2,6 +2,8 @@
 #include "smc.h"
 #include "misc.h"
 
+using namespace arma;
+
 // [[Rcpp::depends(RcppArmadillo)]]
 //' @title Metropolis-Hastings Augmented Ranking
 //' @description Function to perform Metropolis-Hastings for new augmented ranking
@@ -27,13 +29,13 @@ arma::vec metropolis_hastings_aug_ranking(
 	const std::string metric
 ) {
   // augment incomplete ranks to initialise
-  arma::vec ranks = arma_vec_seq(n_items);
+  vec ranks = arma_vec_seq(n_items);
 
   // find items missing from original observed ranking
-  const arma::uvec unranked_items = find_nonfinite(partial_ranking);
+  const uvec unranked_items = find_nonfinite(partial_ranking);
 
   // find unallocated ranks from original observed ranking
-  arma::vec remaining_set = arma_setdiff_vec(current_ranking, partial_ranking, true);
+  vec remaining_set = arma_setdiff_vec(current_ranking, partial_ranking, true);
 
 
   // if the observed and augmented ranking are exactly the same then break
@@ -46,14 +48,14 @@ arma::vec metropolis_hastings_aug_ranking(
   } else {
 
     // generate random order for remaining_set
-    const arma::vec A = arma::shuffle(remaining_set);
+    const vec A = arma::shuffle(remaining_set);
     remaining_set = std::move(A);
 
     // Subset by element position and set equal to the now permuted remaining set
     partial_ranking.elem(unranked_items) = remaining_set;
 
     // set the augmented partial ranking as the proposed augmented ranking
-    const arma::vec& proposed_ranking = partial_ranking;
+    const vec& proposed_ranking = partial_ranking;
 
 
      /* MH TIME ------------------------------------------------------------- */

--- a/src/smc_metropolis_hastings_aug_ranking_pseudo.cpp
+++ b/src/smc_metropolis_hastings_aug_ranking_pseudo.cpp
@@ -2,6 +2,8 @@
 #include "smc.h"
 #include "misc.h"
 
+using namespace arma;
+
 // [[Rcpp::depends(RcppArmadillo)]]
 //' @title Metropolis-Hastings Augmented Ranking (pseudolikelihood)
 //' @description Function to perform Metropolis-Hastings for new augmented ranking using the pseudolikelihood augmentation approach
@@ -29,13 +31,13 @@ arma::vec metropolis_hastings_aug_ranking_pseudo(
 	const std::string metric
 ) {
   // augment incomplete ranks to initialise
-  arma::vec ranks = arma_vec_seq(n_items);
+  vec ranks = arma_vec_seq(n_items);
 
   // find items missing from original observed ranking
-  const arma::uvec unranked_items = find_nonfinite(partial_ranking);
+  const uvec unranked_items = find_nonfinite(partial_ranking);
 
   // find unallocated ranks from original observed ranking
-  const arma::vec remaining_set = arma_setdiff_vec(current_ranking, partial_ranking);
+  const vec remaining_set = arma_setdiff_vec(current_ranking, partial_ranking);
 
   // if the observed and augmented ranking are exactly the same then break
   const bool condition_1 = arma::approx_equal(\
@@ -47,14 +49,14 @@ arma::vec metropolis_hastings_aug_ranking_pseudo(
   } else {
     // randomly permute the unranked items to give the order in which they will
     // be allocated
-    arma::uvec item_ordering = new_pseudo_proposal(unranked_items);
+    uvec item_ordering = new_pseudo_proposal(unranked_items);
 
     // Calculate probabilities
     const Rcpp::List proposal = calculate_forward_probability(\
       item_ordering, partial_ranking, remaining_set, rho, alpha, n_items,\
       metric\
     );
-    const arma::vec& proposed_augmented_ranking = proposal["aug_ranking"];
+    const vec& proposed_augmented_ranking = proposal["aug_ranking"];
     const double& forward_prob = proposal["forward_prob"];
 
     const double backward_prob = calculate_backward_probability(\

--- a/src/smc_metropolis_hastings_rho.cpp
+++ b/src/smc_metropolis_hastings_rho.cpp
@@ -2,6 +2,8 @@
 #include "smc.h"
 #include <cmath>
 
+using namespace arma;
+
 // [[Rcpp::depends(RcppArmadillo)]]
 //' @title Metropolis-Hastings Rho
 //' @description Function to perform Metropolis-Hastings for new rho under the Mallows model with footrule distance metric!
@@ -52,7 +54,7 @@ arma::vec metropolis_hastings_rho(
   const Rcpp::List kernel = leap_and_shift_probs(rho, leap_size, n_items);
 
   // output from leap-and-shift is of the following
-  const arma::vec& rho_prime = Rcpp::as<arma::vec>(kernel["rho_prime"]);
+  const vec& rho_prime = Rcpp::as<vec>(kernel["rho_prime"]);
   const double& forwards_prob = Rcpp::as<double>(kernel["forwards_prob"]); // rho_prime|rho
   const double& backwards_prob = Rcpp::as<double>(kernel["backwards_prob"]); // rho|rho_prime
 


### PR DESCRIPTION
Noticed one thing: In exported functions, we need to keep the `arma::` qualifier even when we have `using namespace arma` on top. For example:

https://github.com/ocbe-uio/BayesMallows/blob/a0bd267215ed3f79b4f88d0e3a4dee4ba594f9f3/src/distances.cpp#L99

Removing `arma::` here leads to error in the generated `RcppExports.cpp`. It seems like we can overcome this by creating a header file `inst/include/BayesMallows.h` where we write `using namespace arma;` (source: https://stackoverflow.com/questions/21944695/rcpparmadillo-and-arma-namespace), but I guess it's best to start with removnig `arma::` in the places where we can.