### PR TITLE
added pdf(NULL)

### DIFF
--- a/tests/testthat/test-sample_mallows.R
+++ b/tests/testthat/test-sample_mallows.R
@@ -35,8 +35,11 @@ test_that(
 test_that("sample_mallows diagnostics work", {
   set.seed(1)
   expect_message(
-    test <- sample_mallows(rho0 = rho0, alpha0 = alpha0, diagnostic = TRUE,
-                           n_samples = 1000, burnin = 1, thinning = 1),
+    {
+      pdf(NULL)
+      test <- sample_mallows(rho0 = rho0, alpha0 = alpha0, diagnostic = TRUE,
+                             n_samples = 1000, burnin = 1, thinning = 1)
+    },
     "Items not provided by user. Picking 5 at random."
   )
   expect_equal(


### PR DESCRIPTION
This is an attempt to fix an issue which is slightly annoying. The function `sample_mallows()` prints a plot when run with `diagnostic = TRUE`, and this causes a file `Rplots.pdf` to be generated when `R CMD check` is run. On GitHub actions this is no problem, but locally it creates a new file that I have to remove. With the given fix this issue is resolved.