### PR TITLE
Fixed CI linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -55,18 +55,17 @@ jobs:
               "R/RcppExports.R"
             )
             style_rules <- list(
-              absolute_path_linter, assignment_linter, closed_curly_linter,
-              commas_linter, commented_code_linter, cyclocomp_linter,
-              equals_na_linter, function_left_parentheses_linter,
-              infix_spaces_linter, line_length_linter, no_tab_linter,
-              nonportable_path_linter, object_length_linter,
-              open_curly_linter, paren_brace_linter, pipe_continuation_linter,
-              semicolon_terminator_linter, seq_linter, single_quotes_linter,
-              spaces_inside_linter, spaces_left_parentheses_linter,
-              T_and_F_symbol_linter, todo_comment_linter,
-              trailing_blank_lines_linter, trailing_whitespace_linter,
-              undesirable_function_linter, undesirable_operator_linter,
-              unneeded_concatenation_linter
+              absolute_path_linter(), assignment_linter(), brace_linter(),
+              commas_linter(), commented_code_linter(), cyclocomp_linter(),
+              equals_na_linter(), function_left_parentheses_linter(),
+              infix_spaces_linter(), line_length_linter(), no_tab_linter(),
+              nonportable_path_linter(), object_length_linter(),
+              pipe_continuation_linter(), seq_linter(), single_quotes_linter(),
+              spaces_inside_linter(), spaces_left_parentheses_linter(),
+              T_and_F_symbol_linter(), todo_comment_linter(),
+              trailing_blank_lines_linter(), trailing_whitespace_linter(),
+              undesirable_function_linter(), undesirable_operator_linter(),
+              unneeded_concatenation_linter()
             )
             lint_package(linters = style_rules, exclusions = excluded_files)
           shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ URL: https://github.com/ocbe-uio/BayesMallows
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 Depends: R (>= 3.5.0)
 Imports: Rcpp (>= 1.0.0),
   ggplot2 (>= 3.1.0),

--- a/man/metropolis_hastings_aug_ranking.Rd
+++ b/man/metropolis_hastings_aug_ranking.Rd
@@ -50,8 +50,8 @@ Function to perform Metropolis-Hastings for new augmented ranking
 }
 \section{Functions}{
 \itemize{
-\item \code{metropolis_hastings_aug_ranking_pseudo}: Deprecated function for
+\item \code{metropolis_hastings_aug_ranking_pseudo()}: Deprecated function for
 \code{metropolis_hastings_aug_ranking_pseudo}.
-}}
 
+}}
 \keyword{internal}

--- a/man/rank_conversion.Rd
+++ b/man/rank_conversion.Rd
@@ -29,11 +29,11 @@ returns a corresponding vector or matrix of ordered items.
 }
 \section{Functions}{
 \itemize{
-\item \code{create_ranking}: Convert from ordering to ranking.
+\item \code{create_ranking()}: Convert from ordering to ranking.
 
-\item \code{create_ordering}: Convert from ranking to ordering.
+\item \code{create_ordering()}: Convert from ranking to ordering.
+
 }}
-
 \examples{
 # A vector of ordered items.
 orderings <- c(5, 1, 2, 4, 3)

--- a/man/smc_mallows_new_item_rank.Rd
+++ b/man/smc_mallows_new_item_rank.Rd
@@ -87,8 +87,8 @@ at each time step. Each correction and augmentation is done by filling in the mi
 }
 \section{Functions}{
 \itemize{
-\item \code{smc_mallows_new_item_rank_alpha_fixed}: Deprecated function for
+\item \code{smc_mallows_new_item_rank_alpha_fixed()}: Deprecated function for
 \code{smc_mallows_new_item_rank_alpha_fixed}.
-}}
 
+}}
 \keyword{internal}

--- a/man/smc_mallows_new_users.Rd
+++ b/man/smc_mallows_new_users.Rd
@@ -133,16 +133,16 @@ receive new users with complete rankings at each time step
 }
 \section{Functions}{
 \itemize{
-\item \code{smc_mallows_new_users_partial}: Deprecated function for
+\item \code{smc_mallows_new_users_partial()}: Deprecated function for
 \code{smc_mallows_new_users_partial}.
 
-\item \code{smc_mallows_new_users_complete}: Deprecated function for
+\item \code{smc_mallows_new_users_complete()}: Deprecated function for
 \code{smc_mallows_new_users_complete}.
 
-\item \code{smc_mallows_new_users_partial_alpha_fixed}: Deprecated function for
+\item \code{smc_mallows_new_users_partial_alpha_fixed()}: Deprecated function for
 \code{smc_mallows_new_users_partial_alpha_fixed}.
-}}
 
+}}
 \examples{
 # Generate basic elements
 data <- sushi_rankings[1:100, ]


### PR DESCRIPTION
Recently-released lintr 3.0.0 broke our CI checks, so the corresponding YAML was updated. This new version seems to also have detect a lot more issues (the same thing happened in other projects of mine). These will be addressed separately, because there are many of them and there's a chance the change could interfere with currently-opened PRs.
