### PR TITLE
Fix @title for sample_dataset

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BayesMallows
 Type: Package
 Title: Bayesian Preference Learning with the Mallows Rank Model
-Version: 1.2.0.9000
+Version: 1.2.0.9001
 Authors@R: c(person("Oystein", "Sorensen",
                     email = "oystein.sorensen.1985@gmail.com",
                     role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,12 @@
-# Development versions
+# BayesMallows (development version)
+
+* Improved documentation of `sample_dataset`
 
 # BayesMallows 1.2.0
 
-* Fixed a bug which caused assess_convergence() to fail with 'parameter = 
+* Fixed a bug which caused assess_convergence() to fail with 'parameter =
   "cluster_probs"'.
-* Fixed a bug in smc_mallows_new_users_partial() and 
+* Fixed a bug in smc_mallows_new_users_partial() and
   smc_mallows_new_users_partial_alpha_fixed().
 * metropolis_hastings_aug_ranking_pseudo() has been deprecated. Please use
   metropolis_hastings_aug_ranking() instead, with pseudo=TRUE.
@@ -41,13 +43,13 @@
 
 # BayesMallows 1.0.4.9001
 
-* This is a major update, with new functions for estimating the Bayesian Mallows 
-  model using sequential Monte Carlo. The methods are described in the vignette 
+* This is a major update, with new functions for estimating the Bayesian Mallows
+  model using sequential Monte Carlo. The methods are described in the vignette
   titled "SMC-Mallows Tutorial".
 
 # BayesMallows 1.0.4.9000
 
-* Removed a large number of dependencies by converting to base R code. This will 
+* Removed a large number of dependencies by converting to base R code. This will
 make the package easier to install across a range of systems, and less vulnerable
 to changes in other packages.
 
@@ -201,7 +203,7 @@ to changes in other packages.
 * Argument `type` to `plot.BayesMallows` and `assess_convergence` has been renamed to `parameter`, to be more consistent.
 
 # BayesMallows 0.1.1.9002
-* Argument `save_augment_data` to `compute_mallows` has been renamed to `save_aug`. 
+* Argument `save_augment_data` to `compute_mallows` has been renamed to `save_aug`.
 * `compute_mallows` fills in implied ranks when an assessor has only one missing rank. This avoids unnecessary augmentation in MCMC.
 * `generate_ranking` and `generate_ordering` now work with missing ranks.
 

--- a/R/data.R
+++ b/R/data.R
@@ -30,7 +30,7 @@
 #' @references \insertAllCited{}
 "sushi_rankings"
 
-#'
+#' A synthetic 3D matrix generated using the sample_mallows function
 #'
 #' A synthetic 3D matrix (\code{n_users}, \code{n_items}, \code{Time}) generated
 #' using the sample_mallows function. These are test datasets used to run

--- a/man/sample_dataset.Rd
+++ b/man/sample_dataset.Rd
@@ -3,18 +3,7 @@
 \docType{data}
 \name{sample_dataset}
 \alias{sample_dataset}
-\title{A synthetic 3D matrix (\code{n_users}, \code{n_items}, \code{Time}) generated
-using the sample_mallows function. These are test datasets used to run
-the SMC-Mallows framework for the cases where we know all of the users
-in our system and their original ranking information are partial rankings.
-However at some point in time, we observe extra information about
-an existing user in the form of a rank for an item that was previously
-not known (\code{NA}). These datasets are very contrived as the first
-time step (\code{sample_dataset[, , 1]}) we observed the top \code{m / 2}
-items from each user, where \code{m} is the number of items in a ranking.
-Then, as we increase the time, we observe the next top ranked item from
-one user at a time, then the next top ranked item, and so on until we have
-a complete dataset at \code{sample_dataset[, , Time]}.}
+\title{A synthetic 3D matrix generated using the sample_mallows function}
 \format{
 An object of class \code{array} of dimension 10 x 6 x 31.
 }


### PR DESCRIPTION
Found this little papercut while working on something else.

The doc for `sample_dataset` is repeating its long description as the title, which is default for Roxygen. I'm proposing a shorter title here, while keeping the description.

NEWS.md updated accordingly, build version bumped up.

