### PR TITLE
Matching SMC defaults to their MCMC counterparts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BayesMallows
 Type: Package
 Title: Bayesian Preference Learning with the Mallows Rank Model
-Version: 1.2.1.9002
+Version: 1.2.1.9003
 Authors@R: c(person("Oystein", "Sorensen",
                     email = "oystein.sorensen.1985@gmail.com",
                     role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ URL: https://github.com/ocbe-uio/BayesMallows
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Depends: R (>= 3.5.0)
 Imports: Rcpp (>= 1.0.0),
   ggplot2 (>= 3.1.0),

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -389,7 +389,7 @@ leap_and_shift_probs <- function(rho, n_items, leap_size = 1L) {
 #' @param alpha numeric value of the scale parameter.
 #' @return a 3d matrix containing: the samples of: rho, alpha and the augmented rankings, and the effective sample size at each iteration of the SMC algorithm.
 #' @export
-smc_mallows_new_item_rank <- function(n_items, R_obs, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init = NULL, rho_samples_init = NULL, alpha_samples_init = 0L, alpha = 0, alpha_prop_sd = 1, lambda = 1, alpha_max = 1, aug_method = "random", verbose = FALSE, alpha_fixed = FALSE, metric = "footrule", leap_size = 1L) {
+smc_mallows_new_item_rank <- function(n_items, R_obs, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init = NULL, rho_samples_init = NULL, alpha_samples_init = 0L, alpha = 0, alpha_prop_sd = 0.5, lambda = 1, alpha_max = 1, aug_method = "random", verbose = FALSE, alpha_fixed = FALSE, metric = "footrule", leap_size = 1L) {
     .Call(`_BayesMallows_smc_mallows_new_item_rank`, n_items, R_obs, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init, rho_samples_init, alpha_samples_init, alpha, alpha_prop_sd, lambda, alpha_max, aug_method, verbose, alpha_fixed, metric, leap_size)
 }
 
@@ -438,7 +438,7 @@ smc_mallows_new_item_rank <- function(n_items, R_obs, N, Time, logz_estimate, mc
 #'
 #' @example inst/examples/smc_mallows_new_users_complete_example.R
 #'
-smc_mallows_new_users <- function(R_obs, type, n_items, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd = 1, lambda = 1, alpha_max = 1, alpha = 0, aug_method = "random", logz_estimate = NULL, verbose = FALSE, metric = "footnote", leap_size = 1L) {
+smc_mallows_new_users <- function(R_obs, type, n_items, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd = 0.5, lambda = 1, alpha_max = 1, alpha = 0, aug_method = "random", logz_estimate = NULL, verbose = FALSE, metric = "footnote", leap_size = 1L) {
     .Call(`_BayesMallows_smc_mallows_new_users`, R_obs, type, n_items, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd, lambda, alpha_max, alpha, aug_method, logz_estimate, verbose, metric, leap_size)
 }
 
@@ -475,8 +475,8 @@ smc_mallows_new_users <- function(R_obs, type, n_items, N, Time, mcmc_kernel_app
 #' @example /inst/examples/metropolis_hastings_alpha_example.R
 #'
 #' @export
-metropolis_hastings_alpha <- function(alpha, n_items, rankings, rho, logz_estimate, alpha_prop_sd, lambda, alpha_max, metric = "footrule") {
-    .Call(`_BayesMallows_metropolis_hastings_alpha`, alpha, n_items, rankings, rho, logz_estimate, alpha_prop_sd, lambda, alpha_max, metric)
+metropolis_hastings_alpha <- function(alpha, n_items, rankings, rho, logz_estimate, lambda, alpha_max, metric = "footrule", alpha_prop_sd = 0.5) {
+    .Call(`_BayesMallows_metropolis_hastings_alpha`, alpha, n_items, rankings, rho, logz_estimate, lambda, alpha_max, metric, alpha_prop_sd)
 }
 
 #' @title Metropolis-Hastings Augmented Ranking

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -196,7 +196,7 @@ run_mcmc <- function(rankings, obs_freq, nmc, constraints, cardinalities, logz_e
 #' @return backward_auxiliary_ranking_probability A numerical value of creating the previous augmented ranking using the same item ordering used to create the
 #' new augmented ranking in calculate_forward_probability function.
 #' @export
-calculate_backward_probability <- function(item_ordering, partial_ranking, current_ranking, remaining_set, rho, alpha, n_items, metric) {
+calculate_backward_probability <- function(item_ordering, partial_ranking, current_ranking, remaining_set, rho, alpha, n_items, metric = "footrule") {
     .Call(`_BayesMallows_calculate_backward_probability`, item_ordering, partial_ranking, current_ranking, remaining_set, rho, alpha, n_items, metric)
 }
 
@@ -224,7 +224,7 @@ calculate_backward_probability <- function(item_ordering, partial_ranking, curre
 #'   proposed augmented ranking and forward_prob a numerical value of the
 #'   probability of creating the augmented ranking using the pseudolikelihood
 #'   augmentation.
-calculate_forward_probability <- function(item_ordering, partial_ranking, remaining_set, rho, alpha, n_items, metric) {
+calculate_forward_probability <- function(item_ordering, partial_ranking, remaining_set, rho, alpha, n_items, metric = "footrule") {
     .Call(`_BayesMallows_calculate_forward_probability`, item_ordering, partial_ranking, remaining_set, rho, alpha, n_items, metric)
 }
 
@@ -262,7 +262,7 @@ correction_kernel <- function(observed_ranking, current_ranking, n_items) {
 #'   \code{"ulam"}.
 #' @return list containing R_obs, the proposed 'corrected' augmented ranking that is compatible with the new observed ranking for a user, and
 #'         forward_auxiliary_ranking_probability, a numerical value for the probability of correcting the ranking to be compatible with R_obs.
-correction_kernel_pseudo <- function(current_ranking, observed_ranking, rho, alpha, n_items, metric) {
+correction_kernel_pseudo <- function(current_ranking, observed_ranking, rho, alpha, n_items, metric = "footrule") {
     .Call(`_BayesMallows_correction_kernel_pseudo`, current_ranking, observed_ranking, rho, alpha, n_items, metric)
 }
 
@@ -311,7 +311,7 @@ correction_kernel_pseudo <- function(current_ranking, observed_ranking, rho, alp
 #'   alpha = alpha, rho = rho,  n_items = n_items, rankings = rankings ,
 #'   metric = metric
 #' )
-get_exponent_sum <- function(alpha, rho, n_items, rankings, metric) {
+get_exponent_sum <- function(alpha, rho, n_items, rankings, metric = "footrule") {
     .Call(`_BayesMallows_get_exponent_sum`, alpha, rho, n_items, rankings, metric)
 }
 
@@ -330,8 +330,8 @@ get_exponent_sum <- function(alpha, rho, n_items, rankings, metric) {
 #' @return sample_prob_list A numeric sequence of sample probabilities for selecting a specific rank given the current
 #'         rho_item_rank
 #' @export
-get_sample_probabilities <- function(rho_item_rank, alpha, remaining_set_ranks, metric, n_items) {
-    .Call(`_BayesMallows_get_sample_probabilities`, rho_item_rank, alpha, remaining_set_ranks, metric, n_items)
+get_sample_probabilities <- function(rho_item_rank, alpha, remaining_set_ranks, n_items, metric = "footrule") {
+    .Call(`_BayesMallows_get_sample_probabilities`, rho_item_rank, alpha, remaining_set_ranks, n_items, metric)
 }
 
 #' @title Leap and Shift Probabilities
@@ -389,8 +389,8 @@ leap_and_shift_probs <- function(rho, leap_size, n_items) {
 #' @param alpha numeric value of the scale parameter.
 #' @return a 3d matrix containing: the samples of: rho, alpha and the augmented rankings, and the effective sample size at each iteration of the SMC algorithm.
 #' @export
-smc_mallows_new_item_rank <- function(n_items, R_obs, metric, leap_size, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init = NULL, rho_samples_init = NULL, alpha_samples_init = 0L, alpha = 0, alpha_prop_sd = 1, lambda = 1, alpha_max = 1, aug_method = "random", verbose = FALSE, alpha_fixed = FALSE) {
-    .Call(`_BayesMallows_smc_mallows_new_item_rank`, n_items, R_obs, metric, leap_size, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init, rho_samples_init, alpha_samples_init, alpha, alpha_prop_sd, lambda, alpha_max, aug_method, verbose, alpha_fixed)
+smc_mallows_new_item_rank <- function(n_items, R_obs, leap_size, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init = NULL, rho_samples_init = NULL, alpha_samples_init = 0L, alpha = 0, alpha_prop_sd = 1, lambda = 1, alpha_max = 1, aug_method = "random", verbose = FALSE, alpha_fixed = FALSE, metric = "footrule") {
+    .Call(`_BayesMallows_smc_mallows_new_item_rank`, n_items, R_obs, leap_size, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init, rho_samples_init, alpha_samples_init, alpha, alpha_prop_sd, lambda, alpha_max, aug_method, verbose, alpha_fixed, metric)
 }
 
 #' @title SMC-Mallows New Users
@@ -438,8 +438,8 @@ smc_mallows_new_item_rank <- function(n_items, R_obs, metric, leap_size, N, Time
 #'
 #' @example inst/examples/smc_mallows_new_users_complete_example.R
 #'
-smc_mallows_new_users <- function(R_obs, type, n_items, metric, leap_size, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd = 1, lambda = 1, alpha_max = 1, alpha = 0, aug_method = "random", logz_estimate = NULL, verbose = FALSE) {
-    .Call(`_BayesMallows_smc_mallows_new_users`, R_obs, type, n_items, metric, leap_size, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd, lambda, alpha_max, alpha, aug_method, logz_estimate, verbose)
+smc_mallows_new_users <- function(R_obs, type, n_items, leap_size, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd = 1, lambda = 1, alpha_max = 1, alpha = 0, aug_method = "random", logz_estimate = NULL, verbose = FALSE, metric = "footnote") {
+    .Call(`_BayesMallows_smc_mallows_new_users`, R_obs, type, n_items, leap_size, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd, lambda, alpha_max, alpha, aug_method, logz_estimate, verbose, metric)
 }
 
 #' @title Metropolis-Hastings Alpha
@@ -475,8 +475,8 @@ smc_mallows_new_users <- function(R_obs, type, n_items, metric, leap_size, N, Ti
 #' @example /inst/examples/metropolis_hastings_alpha_example.R
 #'
 #' @export
-metropolis_hastings_alpha <- function(alpha, n_items, rankings, metric, rho, logz_estimate, alpha_prop_sd, lambda, alpha_max) {
-    .Call(`_BayesMallows_metropolis_hastings_alpha`, alpha, n_items, rankings, metric, rho, logz_estimate, alpha_prop_sd, lambda, alpha_max)
+metropolis_hastings_alpha <- function(alpha, n_items, rankings, rho, logz_estimate, alpha_prop_sd, lambda, alpha_max, metric = "footrule") {
+    .Call(`_BayesMallows_metropolis_hastings_alpha`, alpha, n_items, rankings, rho, logz_estimate, alpha_prop_sd, lambda, alpha_max, metric)
 }
 
 #' @title Metropolis-Hastings Augmented Ranking
@@ -495,8 +495,8 @@ metropolis_hastings_alpha <- function(alpha, n_items, rankings, metric, rho, log
 #' @return R_curr or R_obs A ranking sequence vector representing proposed augmented ranking for next iteration of MCMC chain
 #' @export
 #' @keywords internal
-metropolis_hastings_aug_ranking <- function(alpha, rho, n_items, partial_ranking, current_ranking, metric, pseudo) {
-    .Call(`_BayesMallows_metropolis_hastings_aug_ranking`, alpha, rho, n_items, partial_ranking, current_ranking, metric, pseudo)
+metropolis_hastings_aug_ranking <- function(alpha, rho, n_items, partial_ranking, current_ranking, pseudo, metric = "footnote") {
+    .Call(`_BayesMallows_metropolis_hastings_aug_ranking`, alpha, rho, n_items, partial_ranking, current_ranking, pseudo, metric)
 }
 
 #' @title Metropolis-Hastings Rho
@@ -535,7 +535,7 @@ metropolis_hastings_aug_ranking <- function(alpha, rho, n_items, partial_ranking
 #' 	rho = rho, leap_size = 1
 #' )
 #'
-metropolis_hastings_rho <- function(alpha, n_items, rankings, metric, rho, leap_size) {
-    .Call(`_BayesMallows_metropolis_hastings_rho`, alpha, n_items, rankings, metric, rho, leap_size)
+metropolis_hastings_rho <- function(alpha, n_items, rankings, rho, leap_size, metric = "footnote") {
+    .Call(`_BayesMallows_metropolis_hastings_rho`, alpha, n_items, rankings, rho, leap_size, metric)
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -389,7 +389,7 @@ leap_and_shift_probs <- function(rho, n_items, leap_size = 1L) {
 #' @param alpha numeric value of the scale parameter.
 #' @return a 3d matrix containing: the samples of: rho, alpha and the augmented rankings, and the effective sample size at each iteration of the SMC algorithm.
 #' @export
-smc_mallows_new_item_rank <- function(n_items, R_obs, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init = NULL, rho_samples_init = NULL, alpha_samples_init = 0L, alpha = 0, alpha_prop_sd = 0.5, lambda = 1, alpha_max = 1e6, aug_method = "random", verbose = FALSE, alpha_fixed = FALSE, metric = "footrule", leap_size = 1L) {
+smc_mallows_new_item_rank <- function(n_items, R_obs, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init = NULL, rho_samples_init = NULL, alpha_samples_init = 0L, alpha = 0, alpha_prop_sd = 0.5, lambda = 0.1, alpha_max = 1e6, aug_method = "random", verbose = FALSE, alpha_fixed = FALSE, metric = "footrule", leap_size = 1L) {
     .Call(`_BayesMallows_smc_mallows_new_item_rank`, n_items, R_obs, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init, rho_samples_init, alpha_samples_init, alpha, alpha_prop_sd, lambda, alpha_max, aug_method, verbose, alpha_fixed, metric, leap_size)
 }
 
@@ -438,7 +438,7 @@ smc_mallows_new_item_rank <- function(n_items, R_obs, N, Time, logz_estimate, mc
 #'
 #' @example inst/examples/smc_mallows_new_users_complete_example.R
 #'
-smc_mallows_new_users <- function(R_obs, type, n_items, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd = 0.5, lambda = 1, alpha_max = 1e6, alpha = 0, aug_method = "random", logz_estimate = NULL, verbose = FALSE, metric = "footnote", leap_size = 1L) {
+smc_mallows_new_users <- function(R_obs, type, n_items, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd = 0.5, lambda = 0.1, alpha_max = 1e6, alpha = 0, aug_method = "random", logz_estimate = NULL, verbose = FALSE, metric = "footnote", leap_size = 1L) {
     .Call(`_BayesMallows_smc_mallows_new_users`, R_obs, type, n_items, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd, lambda, alpha_max, alpha, aug_method, logz_estimate, verbose, metric, leap_size)
 }
 
@@ -475,8 +475,8 @@ smc_mallows_new_users <- function(R_obs, type, n_items, N, Time, mcmc_kernel_app
 #' @example /inst/examples/metropolis_hastings_alpha_example.R
 #'
 #' @export
-metropolis_hastings_alpha <- function(alpha, n_items, rankings, rho, logz_estimate, lambda, metric = "footrule", alpha_prop_sd = 0.5, alpha_max = 1e6) {
-    .Call(`_BayesMallows_metropolis_hastings_alpha`, alpha, n_items, rankings, rho, logz_estimate, lambda, metric, alpha_prop_sd, alpha_max)
+metropolis_hastings_alpha <- function(alpha, n_items, rankings, rho, logz_estimate, metric = "footrule", alpha_prop_sd = 0.5, alpha_max = 1e6, lambda = 0.1) {
+    .Call(`_BayesMallows_metropolis_hastings_alpha`, alpha, n_items, rankings, rho, logz_estimate, metric, alpha_prop_sd, alpha_max, lambda)
 }
 
 #' @title Metropolis-Hastings Augmented Ranking

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -353,12 +353,12 @@ get_sample_probabilities <- function(rho_item_rank, alpha, remaining_set_ranks, 
 #' rho <- c(1, 2, 3, 4, 5, 6)
 #' n_items <- 6
 #'
-#' leap_and_shift_probs(rho, 1, n_items)
-#' leap_and_shift_probs(rho, 2, n_items)
-#' leap_and_shift_probs(rho, 3, n_items)
+#' leap_and_shift_probs(rho, n_items, 1)
+#' leap_and_shift_probs(rho, n_items, 2)
+#' leap_and_shift_probs(rho, n_items, 3)
 #'
-leap_and_shift_probs <- function(rho, leap_size, n_items) {
-    .Call(`_BayesMallows_leap_and_shift_probs`, rho, leap_size, n_items)
+leap_and_shift_probs <- function(rho, n_items, leap_size = 1L) {
+    .Call(`_BayesMallows_leap_and_shift_probs`, rho, n_items, leap_size)
 }
 
 #' @title SMC-Mallows new users rank
@@ -389,8 +389,8 @@ leap_and_shift_probs <- function(rho, leap_size, n_items) {
 #' @param alpha numeric value of the scale parameter.
 #' @return a 3d matrix containing: the samples of: rho, alpha and the augmented rankings, and the effective sample size at each iteration of the SMC algorithm.
 #' @export
-smc_mallows_new_item_rank <- function(n_items, R_obs, leap_size, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init = NULL, rho_samples_init = NULL, alpha_samples_init = 0L, alpha = 0, alpha_prop_sd = 1, lambda = 1, alpha_max = 1, aug_method = "random", verbose = FALSE, alpha_fixed = FALSE, metric = "footrule") {
-    .Call(`_BayesMallows_smc_mallows_new_item_rank`, n_items, R_obs, leap_size, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init, rho_samples_init, alpha_samples_init, alpha, alpha_prop_sd, lambda, alpha_max, aug_method, verbose, alpha_fixed, metric)
+smc_mallows_new_item_rank <- function(n_items, R_obs, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init = NULL, rho_samples_init = NULL, alpha_samples_init = 0L, alpha = 0, alpha_prop_sd = 1, lambda = 1, alpha_max = 1, aug_method = "random", verbose = FALSE, alpha_fixed = FALSE, metric = "footrule", leap_size = 1L) {
+    .Call(`_BayesMallows_smc_mallows_new_item_rank`, n_items, R_obs, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init, rho_samples_init, alpha_samples_init, alpha, alpha_prop_sd, lambda, alpha_max, aug_method, verbose, alpha_fixed, metric, leap_size)
 }
 
 #' @title SMC-Mallows New Users
@@ -438,8 +438,8 @@ smc_mallows_new_item_rank <- function(n_items, R_obs, leap_size, N, Time, logz_e
 #'
 #' @example inst/examples/smc_mallows_new_users_complete_example.R
 #'
-smc_mallows_new_users <- function(R_obs, type, n_items, leap_size, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd = 1, lambda = 1, alpha_max = 1, alpha = 0, aug_method = "random", logz_estimate = NULL, verbose = FALSE, metric = "footnote") {
-    .Call(`_BayesMallows_smc_mallows_new_users`, R_obs, type, n_items, leap_size, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd, lambda, alpha_max, alpha, aug_method, logz_estimate, verbose, metric)
+smc_mallows_new_users <- function(R_obs, type, n_items, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd = 1, lambda = 1, alpha_max = 1, alpha = 0, aug_method = "random", logz_estimate = NULL, verbose = FALSE, metric = "footnote", leap_size = 1L) {
+    .Call(`_BayesMallows_smc_mallows_new_users`, R_obs, type, n_items, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd, lambda, alpha_max, alpha, aug_method, logz_estimate, verbose, metric, leap_size)
 }
 
 #' @title Metropolis-Hastings Alpha
@@ -535,7 +535,7 @@ metropolis_hastings_aug_ranking <- function(alpha, rho, n_items, partial_ranking
 #' 	rho = rho, leap_size = 1
 #' )
 #'
-metropolis_hastings_rho <- function(alpha, n_items, rankings, rho, leap_size, metric = "footnote") {
-    .Call(`_BayesMallows_metropolis_hastings_rho`, alpha, n_items, rankings, rho, leap_size, metric)
+metropolis_hastings_rho <- function(alpha, n_items, rankings, rho, metric = "footnote", leap_size = 1L) {
+    .Call(`_BayesMallows_metropolis_hastings_rho`, alpha, n_items, rankings, rho, metric, leap_size)
 }
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -389,7 +389,7 @@ leap_and_shift_probs <- function(rho, n_items, leap_size = 1L) {
 #' @param alpha numeric value of the scale parameter.
 #' @return a 3d matrix containing: the samples of: rho, alpha and the augmented rankings, and the effective sample size at each iteration of the SMC algorithm.
 #' @export
-smc_mallows_new_item_rank <- function(n_items, R_obs, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init = NULL, rho_samples_init = NULL, alpha_samples_init = 0L, alpha = 0, alpha_prop_sd = 0.5, lambda = 1, alpha_max = 1, aug_method = "random", verbose = FALSE, alpha_fixed = FALSE, metric = "footrule", leap_size = 1L) {
+smc_mallows_new_item_rank <- function(n_items, R_obs, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init = NULL, rho_samples_init = NULL, alpha_samples_init = 0L, alpha = 0, alpha_prop_sd = 0.5, lambda = 1, alpha_max = 1e6, aug_method = "random", verbose = FALSE, alpha_fixed = FALSE, metric = "footrule", leap_size = 1L) {
     .Call(`_BayesMallows_smc_mallows_new_item_rank`, n_items, R_obs, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init, rho_samples_init, alpha_samples_init, alpha, alpha_prop_sd, lambda, alpha_max, aug_method, verbose, alpha_fixed, metric, leap_size)
 }
 
@@ -438,7 +438,7 @@ smc_mallows_new_item_rank <- function(n_items, R_obs, N, Time, logz_estimate, mc
 #'
 #' @example inst/examples/smc_mallows_new_users_complete_example.R
 #'
-smc_mallows_new_users <- function(R_obs, type, n_items, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd = 0.5, lambda = 1, alpha_max = 1, alpha = 0, aug_method = "random", logz_estimate = NULL, verbose = FALSE, metric = "footnote", leap_size = 1L) {
+smc_mallows_new_users <- function(R_obs, type, n_items, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd = 0.5, lambda = 1, alpha_max = 1e6, alpha = 0, aug_method = "random", logz_estimate = NULL, verbose = FALSE, metric = "footnote", leap_size = 1L) {
     .Call(`_BayesMallows_smc_mallows_new_users`, R_obs, type, n_items, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd, lambda, alpha_max, alpha, aug_method, logz_estimate, verbose, metric, leap_size)
 }
 
@@ -475,8 +475,8 @@ smc_mallows_new_users <- function(R_obs, type, n_items, N, Time, mcmc_kernel_app
 #' @example /inst/examples/metropolis_hastings_alpha_example.R
 #'
 #' @export
-metropolis_hastings_alpha <- function(alpha, n_items, rankings, rho, logz_estimate, lambda, alpha_max, metric = "footrule", alpha_prop_sd = 0.5) {
-    .Call(`_BayesMallows_metropolis_hastings_alpha`, alpha, n_items, rankings, rho, logz_estimate, lambda, alpha_max, metric, alpha_prop_sd)
+metropolis_hastings_alpha <- function(alpha, n_items, rankings, rho, logz_estimate, lambda, metric = "footrule", alpha_prop_sd = 0.5, alpha_max = 1e6) {
+    .Call(`_BayesMallows_metropolis_hastings_alpha`, alpha, n_items, rankings, rho, logz_estimate, lambda, metric, alpha_prop_sd, alpha_max)
 }
 
 #' @title Metropolis-Hastings Augmented Ranking

--- a/R/smc_mallows_deprecated.R
+++ b/R/smc_mallows_deprecated.R
@@ -7,9 +7,9 @@ smc_mallows_new_users_partial <- function(
 ) {
   .Deprecated("smc_mallows_new_users")
   smc_mallows_new_users(
-    R_obs, "partial", n_items, leap_size, N, Time, mcmc_kernel_app,
+    R_obs, "partial", n_items, N, Time, mcmc_kernel_app,
     num_new_obs, alpha_prop_sd, lambda, alpha_max, 0, aug_method, logz_estimate,
-    verbose, metric
+    verbose, metric, leap_size
   )
 }
 
@@ -22,9 +22,9 @@ smc_mallows_new_users_complete <- function(
 ) {
   .Deprecated("smc_mallows_new_users")
   smc_mallows_new_users(
-    R_obs, "complete", n_items, leap_size, N, Time, mcmc_kernel_app,
+    R_obs, "complete", n_items, N, Time, mcmc_kernel_app,
     num_new_obs, alpha_prop_sd, lambda, alpha_max, 0, "random",
-    logz_estimate, verbose, metric
+    logz_estimate, verbose, metric, leap_size
   )
 }
 
@@ -36,9 +36,9 @@ smc_mallows_new_users_partial_alpha_fixed <- function(
     num_new_obs, aug_method, alpha) {
   .Deprecated("smc_mallows_new_users")
   smc_mallows_new_users(
-    R_obs, "partial_alpha_fixed", n_items, leap_size, N, Time,
+    R_obs, "partial_alpha_fixed", n_items, N, Time,
     mcmc_kernel_app, num_new_obs, 1, 1, 1, alpha, aug_method, logz_estimate,
-    FALSE, metric
+    FALSE, metric, leap_size
   )
 }
 
@@ -53,10 +53,10 @@ smc_mallows_new_item_rank_alpha_fixed <- function(
 ){
   .Deprecated("smc_mallows_new_item_rank")
   smc_mallows_new_item_rank(
-    n_items, R_obs, leap_size, N, Time, logz_estimate, mcmc_kernel_app,
+    n_items, R_obs, N, Time, logz_estimate, mcmc_kernel_app,
     alpha = alpha, alpha_prop_sd = alpha_prop_sd, lambda = lambda,
     alpha_max = alpha_max, aug_method = aug_method, verbose = verbose,
-    alpha_fixed = TRUE, metric = metric
+    alpha_fixed = TRUE, metric = metric, leap_size = leap_size
   )
 }
 

--- a/R/smc_mallows_deprecated.R
+++ b/R/smc_mallows_deprecated.R
@@ -7,9 +7,9 @@ smc_mallows_new_users_partial <- function(
 ) {
   .Deprecated("smc_mallows_new_users")
   smc_mallows_new_users(
-    R_obs, "partial", n_items, metric, leap_size, N, Time, mcmc_kernel_app,
+    R_obs, "partial", n_items, leap_size, N, Time, mcmc_kernel_app,
     num_new_obs, alpha_prop_sd, lambda, alpha_max, 0, aug_method, logz_estimate,
-    verbose
+    verbose, metric
   )
 }
 
@@ -22,9 +22,9 @@ smc_mallows_new_users_complete <- function(
 ) {
   .Deprecated("smc_mallows_new_users")
   smc_mallows_new_users(
-    R_obs, "complete", n_items, metric, leap_size, N, Time, mcmc_kernel_app,
+    R_obs, "complete", n_items, leap_size, N, Time, mcmc_kernel_app,
     num_new_obs, alpha_prop_sd, lambda, alpha_max, 0, "random",
-    logz_estimate, verbose
+    logz_estimate, verbose, metric
   )
 }
 
@@ -36,9 +36,10 @@ smc_mallows_new_users_partial_alpha_fixed <- function(
     num_new_obs, aug_method, alpha) {
   .Deprecated("smc_mallows_new_users")
   smc_mallows_new_users(
-    R_obs, "partial_alpha_fixed", n_items, metric, leap_size, N, Time,
+    R_obs, "partial_alpha_fixed", n_items, leap_size, N, Time,
     mcmc_kernel_app, num_new_obs, 1, 1, 1, alpha, aug_method, logz_estimate,
-    FALSE)
+    FALSE, metric
+  )
 }
 
 #' @describeIn smc_mallows_new_item_rank Deprecated function for
@@ -52,10 +53,10 @@ smc_mallows_new_item_rank_alpha_fixed <- function(
 ){
   .Deprecated("smc_mallows_new_item_rank")
   smc_mallows_new_item_rank(
-    n_items, R_obs, metric, leap_size, N, Time, logz_estimate, mcmc_kernel_app,
+    n_items, R_obs, leap_size, N, Time, logz_estimate, mcmc_kernel_app,
     alpha = alpha, alpha_prop_sd = alpha_prop_sd, lambda = lambda,
     alpha_max = alpha_max, aug_method = aug_method, verbose = verbose,
-    alpha_fixed = TRUE
+    alpha_fixed = TRUE, metric = metric
   )
 }
 
@@ -68,7 +69,7 @@ metropolis_hastings_aug_ranking_pseudo <- function(
 ) {
   .Deprecated("metropolis_hastings_aug_ranking")
   return(metropolis_hastings_aug_ranking(
-    alpha, rho, n_items, partial_ranking, current_ranking, metric, TRUE))
+    alpha, rho, n_items, partial_ranking, current_ranking, TRUE, metric))
 }
 
 #' @describeIn plot.SMCMallows Deprecated function for

--- a/R/smc_post_processing_functions.R
+++ b/R/smc_post_processing_functions.R
@@ -80,7 +80,7 @@ compute_posterior_intervals_rho <- function(output, nmc, burnin, colnames = NULL
 #' @author Anja Stein
 #'
 # AS: added an extra inout variable `colnames`. This is called in the function `smc_processing`.
-compute_rho_consensus <- function(output, nmc, burnin, C, type, colnames = NULL, verbose = FALSE) {
+compute_rho_consensus <- function(output, nmc, burnin, C, type = "CP", colnames = NULL, verbose = FALSE) {
   n_items <- dim(output)[2]
 
   #----------------------------------------------------------------

--- a/R/smc_post_processing_functions.R
+++ b/R/smc_post_processing_functions.R
@@ -4,7 +4,6 @@
 #' @author Anja Stein
 #' @param output input
 #' @param colnames colnames
-# AS: edited this function to include parameter `colnames`. This resolve issues in #118 with post processing functions not printing the names of items in rankings.
 # The `default` is set to NULL so tat we do not cause plotting issues in `plot_rho_heatplot.
 smc_processing <- function(output, colnames = NULL) {
   df <- data.frame(data = output)
@@ -39,8 +38,7 @@ smc_processing <- function(output, colnames = NULL) {
 #' @inheritParams smc_processing
 #' @param nmc Number of Monte Carlo samples
 #' @param burnin A numeric value specifying the number of iterations
-#' to discard as burn-in. Defaults to \code{model_fit$burnin}, and must be
-#' provided if \code{model_fit$burnin} does not exist. See \code{\link{assess_convergence}}.
+#' to discard as burn-in.
 #' @param verbose if \code{TRUE}, prints the final output even if the function
 #' is assigned to an object. Defaults to \code{FALSE}.
 #' @export

--- a/inst/examples/metropolis_hastings_alpha_example.R
+++ b/inst/examples/metropolis_hastings_alpha_example.R
@@ -17,21 +17,21 @@ logz_estimate <- estimate_partition_function(
 )
 
 metropolis_hastings_alpha(
-  alpha, n_items, rankings, metric, rho, logz_estimate, alpha_prop_sd = 0.5,
-  lambda = 0.1, alpha_max = 20
+  alpha, n_items, rankings, rho, logz_estimate, alpha_prop_sd = 0.5,
+  lambda = 0.1, alpha_max = 20, metric
 )
 
 metropolis_hastings_alpha(
-  alpha, n_items, rankings, metric, rho, logz_estimate,
-  alpha_prop_sd = 0.15, lambda = 0.1, alpha_max = 20
+  alpha, n_items, rankings, rho, logz_estimate,
+  alpha_prop_sd = 0.15, lambda = 0.1, alpha_max = 20, metric
 )
 
 metropolis_hastings_alpha(
-  alpha, n_items, rankings, metric, rho, logz_estimate,
-  alpha_prop_sd = 0.5, lambda = 0.15, alpha_max = 20
+  alpha, n_items, rankings, rho, logz_estimate,
+  alpha_prop_sd = 0.5, lambda = 0.15, alpha_max = 20, metric
 )
 
 metropolis_hastings_alpha(
-  alpha, n_items, rankings, metric, rho, logz_estimate,
-  alpha_prop_sd = 0.15, lambda = 0.15, alpha_max = 20
+  alpha, n_items, rankings, rho, logz_estimate,
+  alpha_prop_sd = 0.15, lambda = 0.15, alpha_max = 20, metric
 )

--- a/man/calculate_backward_probability.Rd
+++ b/man/calculate_backward_probability.Rd
@@ -12,7 +12,7 @@ calculate_backward_probability(
   rho,
   alpha,
   n_items,
-  metric
+  metric = "footrule"
 )
 }
 \arguments{

--- a/man/calculate_forward_probability.Rd
+++ b/man/calculate_forward_probability.Rd
@@ -11,7 +11,7 @@ calculate_forward_probability(
   rho,
   alpha,
   n_items,
-  metric
+  metric = "footrule"
 )
 }
 \arguments{

--- a/man/compute_posterior_intervals_alpha.Rd
+++ b/man/compute_posterior_intervals_alpha.Rd
@@ -12,8 +12,7 @@ compute_posterior_intervals_alpha(output, nmc, burnin, verbose = FALSE)
 \item{nmc}{Number of Monte Carlo samples}
 
 \item{burnin}{A numeric value specifying the number of iterations
-to discard as burn-in. Defaults to \code{model_fit$burnin}, and must be
-provided if \code{model_fit$burnin} does not exist. See \code{\link{assess_convergence}}.}
+to discard as burn-in.}
 
 \item{verbose}{if \code{TRUE}, prints the final output even if the function
 is assigned to an object. Defaults to \code{FALSE}.}

--- a/man/compute_posterior_intervals_rho.Rd
+++ b/man/compute_posterior_intervals_rho.Rd
@@ -18,8 +18,7 @@ compute_posterior_intervals_rho(
 \item{nmc}{Number of Monte Carlo samples}
 
 \item{burnin}{A numeric value specifying the number of iterations
-to discard as burn-in. Defaults to \code{model_fit$burnin}, and must be
-provided if \code{model_fit$burnin} does not exist. See \code{\link{assess_convergence}}.}
+to discard as burn-in.}
 
 \item{colnames}{colnames}
 

--- a/man/compute_rho_consensus.Rd
+++ b/man/compute_rho_consensus.Rd
@@ -9,7 +9,7 @@ compute_rho_consensus(
   nmc,
   burnin,
   C,
-  type,
+  type = "CP",
   colnames = NULL,
   verbose = FALSE
 )
@@ -20,8 +20,7 @@ compute_rho_consensus(
 \item{nmc}{Number of Monte Carlo samples}
 
 \item{burnin}{A numeric value specifying the number of iterations
-to discard as burn-in. Defaults to \code{model_fit$burnin}, and must be
-provided if \code{model_fit$burnin} does not exist. See \code{\link{assess_convergence}}.}
+to discard as burn-in.}
 
 \item{C}{C}
 

--- a/man/correction_kernel_pseudo.Rd
+++ b/man/correction_kernel_pseudo.Rd
@@ -10,7 +10,7 @@ correction_kernel_pseudo(
   rho,
   alpha,
   n_items,
-  metric
+  metric = "footrule"
 )
 }
 \arguments{

--- a/man/get_exponent_sum.Rd
+++ b/man/get_exponent_sum.Rd
@@ -4,7 +4,7 @@
 \alias{get_exponent_sum}
 \title{Get exponent in Mallows log-likelihood}
 \usage{
-get_exponent_sum(alpha, rho, n_items, rankings, metric)
+get_exponent_sum(alpha, rho, n_items, rankings, metric = "footrule")
 }
 \arguments{
 \item{alpha}{Numeric value of the scale parameter}

--- a/man/get_sample_probabilities.Rd
+++ b/man/get_sample_probabilities.Rd
@@ -8,8 +8,8 @@ get_sample_probabilities(
   rho_item_rank,
   alpha,
   remaining_set_ranks,
-  metric,
-  n_items
+  n_items,
+  metric = "footrule"
 )
 }
 \arguments{
@@ -19,12 +19,12 @@ get_sample_probabilities(
 
 \item{remaining_set_ranks}{A sequence of integer values of the set of possible ranks that we can assign the item}
 
+\item{n_items}{Integer is the number of items in the consensus ranking}
+
 \item{metric}{A character string specifying the distance metric to use in the
 Bayesian Mallows Model. Available options are \code{"footrule"},
 \code{"spearman"}, \code{"cayley"}, \code{"hamming"}, \code{"kendall"}, and
 \code{"ulam"}.}
-
-\item{n_items}{Integer is the number of items in the consensus ranking}
 }
 \value{
 sample_prob_list A numeric sequence of sample probabilities for selecting a specific rank given the current

--- a/man/leap_and_shift_probs.Rd
+++ b/man/leap_and_shift_probs.Rd
@@ -4,15 +4,15 @@
 \alias{leap_and_shift_probs}
 \title{Leap and Shift Probabilities}
 \usage{
-leap_and_shift_probs(rho, leap_size, n_items)
+leap_and_shift_probs(rho, n_items, leap_size = 1L)
 }
 \arguments{
 \item{rho}{A ranking sequence}
 
+\item{n_items}{Integer is the number of items in a ranking}
+
 \item{leap_size}{Integer specifying the step size of the leap-and-shift
 proposal distribution.}
-
-\item{n_items}{Integer is the number of items in a ranking}
 }
 \value{
 A list containing:
@@ -29,9 +29,9 @@ Calculates transition probabilities for proposing a new rho
 rho <- c(1, 2, 3, 4, 5, 6)
 n_items <- 6
 
-leap_and_shift_probs(rho, 1, n_items)
-leap_and_shift_probs(rho, 2, n_items)
-leap_and_shift_probs(rho, 3, n_items)
+leap_and_shift_probs(rho, n_items, 1)
+leap_and_shift_probs(rho, n_items, 2)
+leap_and_shift_probs(rho, n_items, 3)
 
 }
 \keyword{internal}

--- a/man/metropolis_hastings_alpha.Rd
+++ b/man/metropolis_hastings_alpha.Rd
@@ -10,10 +10,10 @@ metropolis_hastings_alpha(
   rankings,
   rho,
   logz_estimate,
-  lambda,
   metric = "footrule",
   alpha_prop_sd = 0.5,
-  alpha_max = 1e+06
+  alpha_max = 1e+06,
+  lambda = 0.1
 )
 }
 \arguments{
@@ -29,11 +29,6 @@ metropolis_hastings_alpha(
 computed with \code{\link{estimate_partition_function}} in
 the BayesMallow R package {estimate_partition_function}.}
 
-\item{lambda}{Strictly positive numeric value specifying the rate parameter
-of the truncated exponential prior distribution of \eqn{\alpha}. Defaults
-to \code{0.1}. When \code{n_cluster > 1}, each mixture component
-\eqn{\alpha_{c}} has the same prior distribution.}
-
 \item{metric}{A character string specifying the distance metric to use
 in the Bayesian Mallows Model. Available options are \code{"footrule"},
 \code{"spearman"}, \code{"cayley"}, \code{"hamming"}, \code{"kendall"},
@@ -45,6 +40,11 @@ Metropolis-Hastings algorithm. Defaults to \code{0.1}.}
 
 \item{alpha_max}{Maximum value of \code{alpha} in the truncated exponential
 prior distribution.}
+
+\item{lambda}{Strictly positive numeric value specifying the rate parameter
+of the truncated exponential prior distribution of \eqn{\alpha}. Defaults
+to \code{0.1}. When \code{n_cluster > 1}, each mixture component
+\eqn{\alpha_{c}} has the same prior distribution.}
 }
 \value{
 \code{alpha} or \code{alpha_prime}: Numeric value to be used

--- a/man/metropolis_hastings_alpha.Rd
+++ b/man/metropolis_hastings_alpha.Rd
@@ -10,10 +10,10 @@ metropolis_hastings_alpha(
   rankings,
   rho,
   logz_estimate,
-  alpha_prop_sd,
   lambda,
   alpha_max,
-  metric = "footrule"
+  metric = "footrule",
+  alpha_prop_sd = 0.5
 )
 }
 \arguments{
@@ -29,10 +29,6 @@ metropolis_hastings_alpha(
 computed with \code{\link{estimate_partition_function}} in
 the BayesMallow R package {estimate_partition_function}.}
 
-\item{alpha_prop_sd}{Numeric value specifying the standard deviation of the
-lognormal proposal distribution used for \eqn{\alpha} in the
-Metropolis-Hastings algorithm. Defaults to \code{0.1}.}
-
 \item{lambda}{Strictly positive numeric value specifying the rate parameter
 of the truncated exponential prior distribution of \eqn{\alpha}. Defaults
 to \code{0.1}. When \code{n_cluster > 1}, each mixture component
@@ -45,6 +41,10 @@ prior distribution.}
 in the Bayesian Mallows Model. Available options are \code{"footrule"},
 \code{"spearman"}, \code{"cayley"}, \code{"hamming"}, \code{"kendall"},
 and \code{"ulam"}.}
+
+\item{alpha_prop_sd}{Numeric value specifying the standard deviation of the
+lognormal proposal distribution used for \eqn{\alpha} in the
+Metropolis-Hastings algorithm. Defaults to \code{0.1}.}
 }
 \value{
 \code{alpha} or \code{alpha_prime}: Numeric value to be used

--- a/man/metropolis_hastings_alpha.Rd
+++ b/man/metropolis_hastings_alpha.Rd
@@ -11,9 +11,9 @@ metropolis_hastings_alpha(
   rho,
   logz_estimate,
   lambda,
-  alpha_max,
   metric = "footrule",
-  alpha_prop_sd = 0.5
+  alpha_prop_sd = 0.5,
+  alpha_max = 1e+06
 )
 }
 \arguments{
@@ -34,9 +34,6 @@ of the truncated exponential prior distribution of \eqn{\alpha}. Defaults
 to \code{0.1}. When \code{n_cluster > 1}, each mixture component
 \eqn{\alpha_{c}} has the same prior distribution.}
 
-\item{alpha_max}{Maximum value of \code{alpha} in the truncated exponential
-prior distribution.}
-
 \item{metric}{A character string specifying the distance metric to use
 in the Bayesian Mallows Model. Available options are \code{"footrule"},
 \code{"spearman"}, \code{"cayley"}, \code{"hamming"}, \code{"kendall"},
@@ -45,6 +42,9 @@ and \code{"ulam"}.}
 \item{alpha_prop_sd}{Numeric value specifying the standard deviation of the
 lognormal proposal distribution used for \eqn{\alpha} in the
 Metropolis-Hastings algorithm. Defaults to \code{0.1}.}
+
+\item{alpha_max}{Maximum value of \code{alpha} in the truncated exponential
+prior distribution.}
 }
 \value{
 \code{alpha} or \code{alpha_prime}: Numeric value to be used

--- a/man/metropolis_hastings_alpha.Rd
+++ b/man/metropolis_hastings_alpha.Rd
@@ -8,12 +8,12 @@ metropolis_hastings_alpha(
   alpha,
   n_items,
   rankings,
-  metric,
   rho,
   logz_estimate,
   alpha_prop_sd,
   lambda,
-  alpha_max
+  alpha_max,
+  metric = "footrule"
 )
 }
 \arguments{
@@ -22,11 +22,6 @@ metropolis_hastings_alpha(
 \item{n_items}{Integer is the number of items in a ranking}
 
 \item{rankings}{the observed rankings, i.e, preference data}
-
-\item{metric}{A character string specifying the distance metric to use
-in the Bayesian Mallows Model. Available options are \code{"footrule"},
-\code{"spearman"}, \code{"cayley"}, \code{"hamming"}, \code{"kendall"},
-and \code{"ulam"}.}
 
 \item{rho}{Numeric vector specifying the current consensus ranking}
 
@@ -45,6 +40,11 @@ to \code{0.1}. When \code{n_cluster > 1}, each mixture component
 
 \item{alpha_max}{Maximum value of \code{alpha} in the truncated exponential
 prior distribution.}
+
+\item{metric}{A character string specifying the distance metric to use
+in the Bayesian Mallows Model. Available options are \code{"footrule"},
+\code{"spearman"}, \code{"cayley"}, \code{"hamming"}, \code{"kendall"},
+and \code{"ulam"}.}
 }
 \value{
 \code{alpha} or \code{alpha_prime}: Numeric value to be used
@@ -79,23 +79,23 @@ logz_estimate <- estimate_partition_function(
 )
 
 metropolis_hastings_alpha(
-  alpha, n_items, rankings, metric, rho, logz_estimate, alpha_prop_sd = 0.5,
-  lambda = 0.1, alpha_max = 20
+  alpha, n_items, rankings, rho, logz_estimate, alpha_prop_sd = 0.5,
+  lambda = 0.1, alpha_max = 20, metric
 )
 
 metropolis_hastings_alpha(
-  alpha, n_items, rankings, metric, rho, logz_estimate,
-  alpha_prop_sd = 0.15, lambda = 0.1, alpha_max = 20
+  alpha, n_items, rankings, rho, logz_estimate,
+  alpha_prop_sd = 0.15, lambda = 0.1, alpha_max = 20, metric
 )
 
 metropolis_hastings_alpha(
-  alpha, n_items, rankings, metric, rho, logz_estimate,
-  alpha_prop_sd = 0.5, lambda = 0.15, alpha_max = 20
+  alpha, n_items, rankings, rho, logz_estimate,
+  alpha_prop_sd = 0.5, lambda = 0.15, alpha_max = 20, metric
 )
 
 metropolis_hastings_alpha(
-  alpha, n_items, rankings, metric, rho, logz_estimate,
-  alpha_prop_sd = 0.15, lambda = 0.15, alpha_max = 20
+  alpha, n_items, rankings, rho, logz_estimate,
+  alpha_prop_sd = 0.15, lambda = 0.15, alpha_max = 20, metric
 )
 }
 \author{

--- a/man/metropolis_hastings_aug_ranking.Rd
+++ b/man/metropolis_hastings_aug_ranking.Rd
@@ -11,8 +11,8 @@ metropolis_hastings_aug_ranking(
   n_items,
   partial_ranking,
   current_ranking,
-  metric,
-  pseudo
+  pseudo,
+  metric = "footnote"
 )
 
 metropolis_hastings_aug_ranking_pseudo(
@@ -35,12 +35,12 @@ metropolis_hastings_aug_ranking_pseudo(
 
 \item{current_ranking}{An complete rank sequence vector of  the proposed augmented ranking obtained from calculate_forward_probability function}
 
+\item{pseudo}{Boolean specifying whether to use pseudo proposal or not.s}
+
 \item{metric}{A character string specifying the distance metric to use in the
 Bayesian Mallows Model. Available options are \code{"footrule"},
 \code{"spearman"}, \code{"cayley"}, \code{"hamming"}, \code{"kendall"}, and
 \code{"ulam"}.}
-
-\item{pseudo}{Boolean specifying whether to use pseudo proposal or not.s}
 }
 \value{
 R_curr or R_obs A ranking sequence vector representing proposed augmented ranking for next iteration of MCMC chain

--- a/man/metropolis_hastings_rho.Rd
+++ b/man/metropolis_hastings_rho.Rd
@@ -9,8 +9,8 @@ metropolis_hastings_rho(
   n_items,
   rankings,
   rho,
-  leap_size,
-  metric = "footnote"
+  metric = "footnote",
+  leap_size = 1L
 )
 }
 \arguments{
@@ -27,12 +27,12 @@ can be a vector.}
 
 \item{rho}{A ranking sequence}
 
-\item{leap_size}{Integer specifying the step size of the leap-and-shift
-proposal distribution.}
-
 \item{metric}{Character string specifying the distance measure to use.
 Available options are \code{"kendall"}, \code{"cayley"}, \code{"hamming"},
 \code{"ulam"}, \code{"footrule"} and \code{"spearman"}.}
+
+\item{leap_size}{Integer specifying the step size of the leap-and-shift
+proposal distribution.}
 }
 \description{
 Function to perform Metropolis-Hastings for new rho under the Mallows model with footrule distance metric!

--- a/man/metropolis_hastings_rho.Rd
+++ b/man/metropolis_hastings_rho.Rd
@@ -4,7 +4,14 @@
 \alias{metropolis_hastings_rho}
 \title{Metropolis-Hastings Rho}
 \usage{
-metropolis_hastings_rho(alpha, n_items, rankings, metric, rho, leap_size)
+metropolis_hastings_rho(
+  alpha,
+  n_items,
+  rankings,
+  rho,
+  leap_size,
+  metric = "footnote"
+)
 }
 \arguments{
 \item{alpha}{Numeric value of the scale parameter}
@@ -18,14 +25,14 @@ can be a vector.}
 rankings in each row. Alternatively, if \eqn{N} equals 1, \code{rankings}
 can be a vector.}
 
-\item{metric}{Character string specifying the distance measure to use.
-Available options are \code{"kendall"}, \code{"cayley"}, \code{"hamming"},
-\code{"ulam"}, \code{"footrule"} and \code{"spearman"}.}
-
 \item{rho}{A ranking sequence}
 
 \item{leap_size}{Integer specifying the step size of the leap-and-shift
 proposal distribution.}
+
+\item{metric}{Character string specifying the distance measure to use.
+Available options are \code{"kendall"}, \code{"cayley"}, \code{"hamming"},
+\code{"ulam"}, \code{"footrule"} and \code{"spearman"}.}
 }
 \description{
 Function to perform Metropolis-Hastings for new rho under the Mallows model with footrule distance metric!

--- a/man/smc_mallows_new_item_rank.Rd
+++ b/man/smc_mallows_new_item_rank.Rd
@@ -17,7 +17,7 @@ smc_mallows_new_item_rank(
   alpha_samples_init = 0L,
   alpha = 0,
   alpha_prop_sd = 0.5,
-  lambda = 1,
+  lambda = 0.1,
   alpha_max = 1e+06,
   aug_method = "random",
   verbose = FALSE,

--- a/man/smc_mallows_new_item_rank.Rd
+++ b/man/smc_mallows_new_item_rank.Rd
@@ -8,7 +8,6 @@
 smc_mallows_new_item_rank(
   n_items,
   R_obs,
-  metric,
   leap_size,
   N,
   Time,
@@ -23,7 +22,8 @@ smc_mallows_new_item_rank(
   alpha_max = 1,
   aug_method = "random",
   verbose = FALSE,
-  alpha_fixed = FALSE
+  alpha_fixed = FALSE,
+  metric = "footrule"
 )
 
 smc_mallows_new_item_rank_alpha_fixed(
@@ -47,11 +47,6 @@ smc_mallows_new_item_rank_alpha_fixed(
 \item{n_items}{Integer is the number of items in a ranking}
 
 \item{R_obs}{3D matrix of size n_assessors by n_items by Time containing a set of observed rankings of Time time steps}
-
-\item{metric}{A character string specifying the distance metric to use in the
-Bayesian Mallows Model. Available options are \code{"footrule"},
-\code{"spearman"}, \code{"cayley"}, \code{"hamming"}, \code{"kendall"}, and
-\code{"ulam"}.}
 
 \item{leap_size}{leap_size Integer specifying the step size of the leap-and-shift
 proposal distribution}
@@ -81,6 +76,11 @@ prior distribution.}
 SMC-Mallows algorithm. Defaults to \code{FALSE}.}
 
 \item{alpha_fixed}{Logical indicating whether to sample \code{alpha} or not.}
+
+\item{metric}{A character string specifying the distance metric to use in the
+Bayesian Mallows Model. Available options are \code{"footrule"},
+\code{"spearman"}, \code{"cayley"}, \code{"hamming"}, \code{"kendall"}, and
+\code{"ulam"}.}
 }
 \value{
 a 3d matrix containing: the samples of: rho, alpha and the augmented rankings, and the effective sample size at each iteration of the SMC algorithm.

--- a/man/smc_mallows_new_item_rank.Rd
+++ b/man/smc_mallows_new_item_rank.Rd
@@ -18,7 +18,7 @@ smc_mallows_new_item_rank(
   alpha = 0,
   alpha_prop_sd = 0.5,
   lambda = 1,
-  alpha_max = 1,
+  alpha_max = 1e+06,
   aug_method = "random",
   verbose = FALSE,
   alpha_fixed = FALSE,

--- a/man/smc_mallows_new_item_rank.Rd
+++ b/man/smc_mallows_new_item_rank.Rd
@@ -8,7 +8,6 @@
 smc_mallows_new_item_rank(
   n_items,
   R_obs,
-  leap_size,
   N,
   Time,
   logz_estimate,
@@ -23,7 +22,8 @@ smc_mallows_new_item_rank(
   aug_method = "random",
   verbose = FALSE,
   alpha_fixed = FALSE,
-  metric = "footrule"
+  metric = "footrule",
+  leap_size = 1L
 )
 
 smc_mallows_new_item_rank_alpha_fixed(
@@ -47,9 +47,6 @@ smc_mallows_new_item_rank_alpha_fixed(
 \item{n_items}{Integer is the number of items in a ranking}
 
 \item{R_obs}{3D matrix of size n_assessors by n_items by Time containing a set of observed rankings of Time time steps}
-
-\item{leap_size}{leap_size Integer specifying the step size of the leap-and-shift
-proposal distribution}
 
 \item{N}{Integer specifying the number of particles}
 
@@ -81,6 +78,9 @@ SMC-Mallows algorithm. Defaults to \code{FALSE}.}
 Bayesian Mallows Model. Available options are \code{"footrule"},
 \code{"spearman"}, \code{"cayley"}, \code{"hamming"}, \code{"kendall"}, and
 \code{"ulam"}.}
+
+\item{leap_size}{leap_size Integer specifying the step size of the leap-and-shift
+proposal distribution}
 }
 \value{
 a 3d matrix containing: the samples of: rho, alpha and the augmented rankings, and the effective sample size at each iteration of the SMC algorithm.

--- a/man/smc_mallows_new_item_rank.Rd
+++ b/man/smc_mallows_new_item_rank.Rd
@@ -16,7 +16,7 @@ smc_mallows_new_item_rank(
   rho_samples_init = NULL,
   alpha_samples_init = 0L,
   alpha = 0,
-  alpha_prop_sd = 1,
+  alpha_prop_sd = 0.5,
   lambda = 1,
   alpha_max = 1,
   aug_method = "random",

--- a/man/smc_mallows_new_users.Rd
+++ b/man/smc_mallows_new_users.Rd
@@ -17,7 +17,7 @@ smc_mallows_new_users(
   num_new_obs,
   alpha_prop_sd = 0.5,
   lambda = 1,
-  alpha_max = 1,
+  alpha_max = 1e+06,
   alpha = 0,
   aug_method = "random",
   logz_estimate = NULL,

--- a/man/smc_mallows_new_users.Rd
+++ b/man/smc_mallows_new_users.Rd
@@ -15,7 +15,7 @@ smc_mallows_new_users(
   Time,
   mcmc_kernel_app,
   num_new_obs,
-  alpha_prop_sd = 1,
+  alpha_prop_sd = 0.5,
   lambda = 1,
   alpha_max = 1,
   alpha = 0,

--- a/man/smc_mallows_new_users.Rd
+++ b/man/smc_mallows_new_users.Rd
@@ -11,7 +11,6 @@ smc_mallows_new_users(
   R_obs,
   type,
   n_items,
-  metric,
   leap_size,
   N,
   Time,
@@ -23,7 +22,8 @@ smc_mallows_new_users(
   alpha = 0,
   aug_method = "random",
   logz_estimate = NULL,
-  verbose = FALSE
+  verbose = FALSE,
+  metric = "footnote"
 )
 
 smc_mallows_new_users_partial(
@@ -82,11 +82,6 @@ n_assessors by n_items}
 
 \item{n_items}{Integer is the number of items in a ranking}
 
-\item{metric}{A character string specifying the distance metric to use
-in the Bayesian Mallows Model. Available options are \code{"footrule"},
-\code{"spearman"}, \code{"cayley"}, \code{"hamming"}, \code{"kendall"}, and
-\code{"ulam"}.}
-
 \item{leap_size}{leap_size Integer specifying the step size of the
 leap-and-shift proposal distribution}
 
@@ -123,6 +118,11 @@ in the missing data, options are "pseudolikelihood" or "random".}
 
 \item{verbose}{Logical specifying whether to print out the progress of the
 SMC-Mallows algorithm. Defaults to \code{FALSE}.}
+
+\item{metric}{A character string specifying the distance metric to use
+in the Bayesian Mallows Model. Available options are \code{"footrule"},
+\code{"spearman"}, \code{"cayley"}, \code{"hamming"}, \code{"kendall"}, and
+\code{"ulam"}.}
 }
 \value{
 a set of particles each containing a value of rho and alpha

--- a/man/smc_mallows_new_users.Rd
+++ b/man/smc_mallows_new_users.Rd
@@ -16,7 +16,7 @@ smc_mallows_new_users(
   mcmc_kernel_app,
   num_new_obs,
   alpha_prop_sd = 0.5,
-  lambda = 1,
+  lambda = 0.1,
   alpha_max = 1e+06,
   alpha = 0,
   aug_method = "random",

--- a/man/smc_mallows_new_users.Rd
+++ b/man/smc_mallows_new_users.Rd
@@ -11,7 +11,6 @@ smc_mallows_new_users(
   R_obs,
   type,
   n_items,
-  leap_size,
   N,
   Time,
   mcmc_kernel_app,
@@ -23,7 +22,8 @@ smc_mallows_new_users(
   aug_method = "random",
   logz_estimate = NULL,
   verbose = FALSE,
-  metric = "footnote"
+  metric = "footnote",
+  leap_size = 1L
 )
 
 smc_mallows_new_users_partial(
@@ -82,9 +82,6 @@ n_assessors by n_items}
 
 \item{n_items}{Integer is the number of items in a ranking}
 
-\item{leap_size}{leap_size Integer specifying the step size of the
-leap-and-shift proposal distribution}
-
 \item{N}{Integer specifying the number of particles}
 
 \item{Time}{Integer specifying the number of time steps in the SMC algorithm}
@@ -123,6 +120,9 @@ SMC-Mallows algorithm. Defaults to \code{FALSE}.}
 in the Bayesian Mallows Model. Available options are \code{"footrule"},
 \code{"spearman"}, \code{"cayley"}, \code{"hamming"}, \code{"kendall"}, and
 \code{"ulam"}.}
+
+\item{leap_size}{leap_size Integer specifying the step size of the
+leap-and-shift proposal distribution}
 }
 \value{
 a set of particles each containing a value of rho and alpha

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -328,8 +328,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // metropolis_hastings_alpha
-double metropolis_hastings_alpha(const double alpha, const int n_items, const arma::mat rankings, const arma::vec rho, const Rcpp::Nullable<arma::vec> logz_estimate, const double alpha_prop_sd, const double lambda, const double alpha_max, const std::string metric);
-RcppExport SEXP _BayesMallows_metropolis_hastings_alpha(SEXP alphaSEXP, SEXP n_itemsSEXP, SEXP rankingsSEXP, SEXP rhoSEXP, SEXP logz_estimateSEXP, SEXP alpha_prop_sdSEXP, SEXP lambdaSEXP, SEXP alpha_maxSEXP, SEXP metricSEXP) {
+double metropolis_hastings_alpha(const double alpha, const int n_items, const arma::mat rankings, const arma::vec rho, const Rcpp::Nullable<arma::vec> logz_estimate, const double lambda, const double alpha_max, const std::string metric, const double alpha_prop_sd);
+RcppExport SEXP _BayesMallows_metropolis_hastings_alpha(SEXP alphaSEXP, SEXP n_itemsSEXP, SEXP rankingsSEXP, SEXP rhoSEXP, SEXP logz_estimateSEXP, SEXP lambdaSEXP, SEXP alpha_maxSEXP, SEXP metricSEXP, SEXP alpha_prop_sdSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -338,11 +338,11 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const arma::mat >::type rankings(rankingsSEXP);
     Rcpp::traits::input_parameter< const arma::vec >::type rho(rhoSEXP);
     Rcpp::traits::input_parameter< const Rcpp::Nullable<arma::vec> >::type logz_estimate(logz_estimateSEXP);
-    Rcpp::traits::input_parameter< const double >::type alpha_prop_sd(alpha_prop_sdSEXP);
     Rcpp::traits::input_parameter< const double >::type lambda(lambdaSEXP);
     Rcpp::traits::input_parameter< const double >::type alpha_max(alpha_maxSEXP);
     Rcpp::traits::input_parameter< const std::string >::type metric(metricSEXP);
-    rcpp_result_gen = Rcpp::wrap(metropolis_hastings_alpha(alpha, n_items, rankings, rho, logz_estimate, alpha_prop_sd, lambda, alpha_max, metric));
+    Rcpp::traits::input_parameter< const double >::type alpha_prop_sd(alpha_prop_sdSEXP);
+    rcpp_result_gen = Rcpp::wrap(metropolis_hastings_alpha(alpha, n_items, rankings, rho, logz_estimate, lambda, alpha_max, metric, alpha_prop_sd));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -328,8 +328,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // metropolis_hastings_alpha
-double metropolis_hastings_alpha(const double alpha, const int n_items, const arma::mat rankings, const arma::vec rho, const Rcpp::Nullable<arma::vec> logz_estimate, const double lambda, const std::string metric, const double alpha_prop_sd, const double alpha_max);
-RcppExport SEXP _BayesMallows_metropolis_hastings_alpha(SEXP alphaSEXP, SEXP n_itemsSEXP, SEXP rankingsSEXP, SEXP rhoSEXP, SEXP logz_estimateSEXP, SEXP lambdaSEXP, SEXP metricSEXP, SEXP alpha_prop_sdSEXP, SEXP alpha_maxSEXP) {
+double metropolis_hastings_alpha(const double alpha, const int n_items, const arma::mat rankings, const arma::vec rho, const Rcpp::Nullable<arma::vec> logz_estimate, const std::string metric, const double alpha_prop_sd, const double alpha_max, const double lambda);
+RcppExport SEXP _BayesMallows_metropolis_hastings_alpha(SEXP alphaSEXP, SEXP n_itemsSEXP, SEXP rankingsSEXP, SEXP rhoSEXP, SEXP logz_estimateSEXP, SEXP metricSEXP, SEXP alpha_prop_sdSEXP, SEXP alpha_maxSEXP, SEXP lambdaSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -338,11 +338,11 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const arma::mat >::type rankings(rankingsSEXP);
     Rcpp::traits::input_parameter< const arma::vec >::type rho(rhoSEXP);
     Rcpp::traits::input_parameter< const Rcpp::Nullable<arma::vec> >::type logz_estimate(logz_estimateSEXP);
-    Rcpp::traits::input_parameter< const double >::type lambda(lambdaSEXP);
     Rcpp::traits::input_parameter< const std::string >::type metric(metricSEXP);
     Rcpp::traits::input_parameter< const double >::type alpha_prop_sd(alpha_prop_sdSEXP);
     Rcpp::traits::input_parameter< const double >::type alpha_max(alpha_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(metropolis_hastings_alpha(alpha, n_items, rankings, rho, logz_estimate, lambda, metric, alpha_prop_sd, alpha_max));
+    Rcpp::traits::input_parameter< const double >::type lambda(lambdaSEXP);
+    rcpp_result_gen = Rcpp::wrap(metropolis_hastings_alpha(alpha, n_items, rankings, rho, logz_estimate, metric, alpha_prop_sd, alpha_max, lambda));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -261,27 +261,26 @@ BEGIN_RCPP
 END_RCPP
 }
 // leap_and_shift_probs
-Rcpp::List leap_and_shift_probs(const arma::vec rho, const int leap_size, const int n_items);
-RcppExport SEXP _BayesMallows_leap_and_shift_probs(SEXP rhoSEXP, SEXP leap_sizeSEXP, SEXP n_itemsSEXP) {
+Rcpp::List leap_and_shift_probs(const arma::vec rho, const int n_items, const int leap_size);
+RcppExport SEXP _BayesMallows_leap_and_shift_probs(SEXP rhoSEXP, SEXP n_itemsSEXP, SEXP leap_sizeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const arma::vec >::type rho(rhoSEXP);
-    Rcpp::traits::input_parameter< const int >::type leap_size(leap_sizeSEXP);
     Rcpp::traits::input_parameter< const int >::type n_items(n_itemsSEXP);
-    rcpp_result_gen = Rcpp::wrap(leap_and_shift_probs(rho, leap_size, n_items));
+    Rcpp::traits::input_parameter< const int >::type leap_size(leap_sizeSEXP);
+    rcpp_result_gen = Rcpp::wrap(leap_and_shift_probs(rho, n_items, leap_size));
     return rcpp_result_gen;
 END_RCPP
 }
 // smc_mallows_new_item_rank
-Rcpp::List smc_mallows_new_item_rank(const unsigned int& n_items, arma::cube& R_obs, const int& leap_size, const unsigned int& N, const unsigned int Time, const Rcpp::Nullable<arma::vec> logz_estimate, const int& mcmc_kernel_app, Rcpp::Nullable<arma::cube> aug_rankings_init, Rcpp::Nullable<arma::mat> rho_samples_init, arma::vec alpha_samples_init, const double alpha, const double alpha_prop_sd, const double lambda, const double alpha_max, const std::string& aug_method, const bool verbose, const bool alpha_fixed, const std::string& metric);
-RcppExport SEXP _BayesMallows_smc_mallows_new_item_rank(SEXP n_itemsSEXP, SEXP R_obsSEXP, SEXP leap_sizeSEXP, SEXP NSEXP, SEXP TimeSEXP, SEXP logz_estimateSEXP, SEXP mcmc_kernel_appSEXP, SEXP aug_rankings_initSEXP, SEXP rho_samples_initSEXP, SEXP alpha_samples_initSEXP, SEXP alphaSEXP, SEXP alpha_prop_sdSEXP, SEXP lambdaSEXP, SEXP alpha_maxSEXP, SEXP aug_methodSEXP, SEXP verboseSEXP, SEXP alpha_fixedSEXP, SEXP metricSEXP) {
+Rcpp::List smc_mallows_new_item_rank(const unsigned int& n_items, arma::cube& R_obs, const unsigned int& N, const unsigned int Time, const Rcpp::Nullable<arma::vec> logz_estimate, const int& mcmc_kernel_app, Rcpp::Nullable<arma::cube> aug_rankings_init, Rcpp::Nullable<arma::mat> rho_samples_init, arma::vec alpha_samples_init, const double alpha, const double alpha_prop_sd, const double lambda, const double alpha_max, const std::string& aug_method, const bool verbose, const bool alpha_fixed, const std::string& metric, const int& leap_size);
+RcppExport SEXP _BayesMallows_smc_mallows_new_item_rank(SEXP n_itemsSEXP, SEXP R_obsSEXP, SEXP NSEXP, SEXP TimeSEXP, SEXP logz_estimateSEXP, SEXP mcmc_kernel_appSEXP, SEXP aug_rankings_initSEXP, SEXP rho_samples_initSEXP, SEXP alpha_samples_initSEXP, SEXP alphaSEXP, SEXP alpha_prop_sdSEXP, SEXP lambdaSEXP, SEXP alpha_maxSEXP, SEXP aug_methodSEXP, SEXP verboseSEXP, SEXP alpha_fixedSEXP, SEXP metricSEXP, SEXP leap_sizeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const unsigned int& >::type n_items(n_itemsSEXP);
     Rcpp::traits::input_parameter< arma::cube& >::type R_obs(R_obsSEXP);
-    Rcpp::traits::input_parameter< const int& >::type leap_size(leap_sizeSEXP);
     Rcpp::traits::input_parameter< const unsigned int& >::type N(NSEXP);
     Rcpp::traits::input_parameter< const unsigned int >::type Time(TimeSEXP);
     Rcpp::traits::input_parameter< const Rcpp::Nullable<arma::vec> >::type logz_estimate(logz_estimateSEXP);
@@ -297,20 +296,20 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const bool >::type verbose(verboseSEXP);
     Rcpp::traits::input_parameter< const bool >::type alpha_fixed(alpha_fixedSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type metric(metricSEXP);
-    rcpp_result_gen = Rcpp::wrap(smc_mallows_new_item_rank(n_items, R_obs, leap_size, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init, rho_samples_init, alpha_samples_init, alpha, alpha_prop_sd, lambda, alpha_max, aug_method, verbose, alpha_fixed, metric));
+    Rcpp::traits::input_parameter< const int& >::type leap_size(leap_sizeSEXP);
+    rcpp_result_gen = Rcpp::wrap(smc_mallows_new_item_rank(n_items, R_obs, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init, rho_samples_init, alpha_samples_init, alpha, alpha_prop_sd, lambda, alpha_max, aug_method, verbose, alpha_fixed, metric, leap_size));
     return rcpp_result_gen;
 END_RCPP
 }
 // smc_mallows_new_users
-Rcpp::List smc_mallows_new_users(const arma::mat& R_obs, const std::string& type, const int& n_items, const int& leap_size, const int& N, int Time, const int& mcmc_kernel_app, const int& num_new_obs, const double alpha_prop_sd, const double lambda, const double alpha_max, const double alpha, const std::string& aug_method, const Rcpp::Nullable<arma::vec>& logz_estimate, const bool verbose, const std::string& metric);
-RcppExport SEXP _BayesMallows_smc_mallows_new_users(SEXP R_obsSEXP, SEXP typeSEXP, SEXP n_itemsSEXP, SEXP leap_sizeSEXP, SEXP NSEXP, SEXP TimeSEXP, SEXP mcmc_kernel_appSEXP, SEXP num_new_obsSEXP, SEXP alpha_prop_sdSEXP, SEXP lambdaSEXP, SEXP alpha_maxSEXP, SEXP alphaSEXP, SEXP aug_methodSEXP, SEXP logz_estimateSEXP, SEXP verboseSEXP, SEXP metricSEXP) {
+Rcpp::List smc_mallows_new_users(const arma::mat& R_obs, const std::string& type, const int& n_items, const int& N, int Time, const int& mcmc_kernel_app, const int& num_new_obs, const double alpha_prop_sd, const double lambda, const double alpha_max, const double alpha, const std::string& aug_method, const Rcpp::Nullable<arma::vec>& logz_estimate, const bool verbose, const std::string& metric, const int& leap_size);
+RcppExport SEXP _BayesMallows_smc_mallows_new_users(SEXP R_obsSEXP, SEXP typeSEXP, SEXP n_itemsSEXP, SEXP NSEXP, SEXP TimeSEXP, SEXP mcmc_kernel_appSEXP, SEXP num_new_obsSEXP, SEXP alpha_prop_sdSEXP, SEXP lambdaSEXP, SEXP alpha_maxSEXP, SEXP alphaSEXP, SEXP aug_methodSEXP, SEXP logz_estimateSEXP, SEXP verboseSEXP, SEXP metricSEXP, SEXP leap_sizeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const arma::mat& >::type R_obs(R_obsSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type type(typeSEXP);
     Rcpp::traits::input_parameter< const int& >::type n_items(n_itemsSEXP);
-    Rcpp::traits::input_parameter< const int& >::type leap_size(leap_sizeSEXP);
     Rcpp::traits::input_parameter< const int& >::type N(NSEXP);
     Rcpp::traits::input_parameter< int >::type Time(TimeSEXP);
     Rcpp::traits::input_parameter< const int& >::type mcmc_kernel_app(mcmc_kernel_appSEXP);
@@ -323,7 +322,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::Nullable<arma::vec>& >::type logz_estimate(logz_estimateSEXP);
     Rcpp::traits::input_parameter< const bool >::type verbose(verboseSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type metric(metricSEXP);
-    rcpp_result_gen = Rcpp::wrap(smc_mallows_new_users(R_obs, type, n_items, leap_size, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd, lambda, alpha_max, alpha, aug_method, logz_estimate, verbose, metric));
+    Rcpp::traits::input_parameter< const int& >::type leap_size(leap_sizeSEXP);
+    rcpp_result_gen = Rcpp::wrap(smc_mallows_new_users(R_obs, type, n_items, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd, lambda, alpha_max, alpha, aug_method, logz_estimate, verbose, metric, leap_size));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -364,8 +364,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // metropolis_hastings_rho
-arma::vec metropolis_hastings_rho(const double alpha, const int n_items, const arma::mat rankings, const arma::vec rho, const int leap_size, const std::string metric);
-RcppExport SEXP _BayesMallows_metropolis_hastings_rho(SEXP alphaSEXP, SEXP n_itemsSEXP, SEXP rankingsSEXP, SEXP rhoSEXP, SEXP leap_sizeSEXP, SEXP metricSEXP) {
+arma::vec metropolis_hastings_rho(const double alpha, const int n_items, const arma::mat rankings, const arma::vec rho, const std::string metric, const int leap_size);
+RcppExport SEXP _BayesMallows_metropolis_hastings_rho(SEXP alphaSEXP, SEXP n_itemsSEXP, SEXP rankingsSEXP, SEXP rhoSEXP, SEXP metricSEXP, SEXP leap_sizeSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -373,9 +373,9 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int >::type n_items(n_itemsSEXP);
     Rcpp::traits::input_parameter< const arma::mat >::type rankings(rankingsSEXP);
     Rcpp::traits::input_parameter< const arma::vec >::type rho(rhoSEXP);
-    Rcpp::traits::input_parameter< const int >::type leap_size(leap_sizeSEXP);
     Rcpp::traits::input_parameter< const std::string >::type metric(metricSEXP);
-    rcpp_result_gen = Rcpp::wrap(metropolis_hastings_rho(alpha, n_items, rankings, rho, leap_size, metric));
+    Rcpp::traits::input_parameter< const int >::type leap_size(leap_sizeSEXP);
+    rcpp_result_gen = Rcpp::wrap(metropolis_hastings_rho(alpha, n_items, rankings, rho, metric, leap_size));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -246,17 +246,17 @@ BEGIN_RCPP
 END_RCPP
 }
 // get_sample_probabilities
-arma::vec get_sample_probabilities(const arma::vec rho_item_rank, const double alpha, const arma::vec remaining_set_ranks, const std::string metric, const int n_items);
-RcppExport SEXP _BayesMallows_get_sample_probabilities(SEXP rho_item_rankSEXP, SEXP alphaSEXP, SEXP remaining_set_ranksSEXP, SEXP metricSEXP, SEXP n_itemsSEXP) {
+arma::vec get_sample_probabilities(const arma::vec rho_item_rank, const double alpha, const arma::vec remaining_set_ranks, const int n_items, const std::string metric);
+RcppExport SEXP _BayesMallows_get_sample_probabilities(SEXP rho_item_rankSEXP, SEXP alphaSEXP, SEXP remaining_set_ranksSEXP, SEXP n_itemsSEXP, SEXP metricSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const arma::vec >::type rho_item_rank(rho_item_rankSEXP);
     Rcpp::traits::input_parameter< const double >::type alpha(alphaSEXP);
     Rcpp::traits::input_parameter< const arma::vec >::type remaining_set_ranks(remaining_set_ranksSEXP);
-    Rcpp::traits::input_parameter< const std::string >::type metric(metricSEXP);
     Rcpp::traits::input_parameter< const int >::type n_items(n_itemsSEXP);
-    rcpp_result_gen = Rcpp::wrap(get_sample_probabilities(rho_item_rank, alpha, remaining_set_ranks, metric, n_items));
+    Rcpp::traits::input_parameter< const std::string >::type metric(metricSEXP);
+    rcpp_result_gen = Rcpp::wrap(get_sample_probabilities(rho_item_rank, alpha, remaining_set_ranks, n_items, metric));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -274,14 +274,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // smc_mallows_new_item_rank
-Rcpp::List smc_mallows_new_item_rank(const unsigned int& n_items, arma::cube& R_obs, const std::string& metric, const int& leap_size, const unsigned int& N, const unsigned int Time, const Rcpp::Nullable<arma::vec> logz_estimate, const int& mcmc_kernel_app, Rcpp::Nullable<arma::cube> aug_rankings_init, Rcpp::Nullable<arma::mat> rho_samples_init, arma::vec alpha_samples_init, const double alpha, const double alpha_prop_sd, const double lambda, const double alpha_max, const std::string& aug_method, const bool verbose, const bool alpha_fixed);
-RcppExport SEXP _BayesMallows_smc_mallows_new_item_rank(SEXP n_itemsSEXP, SEXP R_obsSEXP, SEXP metricSEXP, SEXP leap_sizeSEXP, SEXP NSEXP, SEXP TimeSEXP, SEXP logz_estimateSEXP, SEXP mcmc_kernel_appSEXP, SEXP aug_rankings_initSEXP, SEXP rho_samples_initSEXP, SEXP alpha_samples_initSEXP, SEXP alphaSEXP, SEXP alpha_prop_sdSEXP, SEXP lambdaSEXP, SEXP alpha_maxSEXP, SEXP aug_methodSEXP, SEXP verboseSEXP, SEXP alpha_fixedSEXP) {
+Rcpp::List smc_mallows_new_item_rank(const unsigned int& n_items, arma::cube& R_obs, const int& leap_size, const unsigned int& N, const unsigned int Time, const Rcpp::Nullable<arma::vec> logz_estimate, const int& mcmc_kernel_app, Rcpp::Nullable<arma::cube> aug_rankings_init, Rcpp::Nullable<arma::mat> rho_samples_init, arma::vec alpha_samples_init, const double alpha, const double alpha_prop_sd, const double lambda, const double alpha_max, const std::string& aug_method, const bool verbose, const bool alpha_fixed, const std::string& metric);
+RcppExport SEXP _BayesMallows_smc_mallows_new_item_rank(SEXP n_itemsSEXP, SEXP R_obsSEXP, SEXP leap_sizeSEXP, SEXP NSEXP, SEXP TimeSEXP, SEXP logz_estimateSEXP, SEXP mcmc_kernel_appSEXP, SEXP aug_rankings_initSEXP, SEXP rho_samples_initSEXP, SEXP alpha_samples_initSEXP, SEXP alphaSEXP, SEXP alpha_prop_sdSEXP, SEXP lambdaSEXP, SEXP alpha_maxSEXP, SEXP aug_methodSEXP, SEXP verboseSEXP, SEXP alpha_fixedSEXP, SEXP metricSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const unsigned int& >::type n_items(n_itemsSEXP);
     Rcpp::traits::input_parameter< arma::cube& >::type R_obs(R_obsSEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type metric(metricSEXP);
     Rcpp::traits::input_parameter< const int& >::type leap_size(leap_sizeSEXP);
     Rcpp::traits::input_parameter< const unsigned int& >::type N(NSEXP);
     Rcpp::traits::input_parameter< const unsigned int >::type Time(TimeSEXP);
@@ -297,20 +296,20 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const std::string& >::type aug_method(aug_methodSEXP);
     Rcpp::traits::input_parameter< const bool >::type verbose(verboseSEXP);
     Rcpp::traits::input_parameter< const bool >::type alpha_fixed(alpha_fixedSEXP);
-    rcpp_result_gen = Rcpp::wrap(smc_mallows_new_item_rank(n_items, R_obs, metric, leap_size, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init, rho_samples_init, alpha_samples_init, alpha, alpha_prop_sd, lambda, alpha_max, aug_method, verbose, alpha_fixed));
+    Rcpp::traits::input_parameter< const std::string& >::type metric(metricSEXP);
+    rcpp_result_gen = Rcpp::wrap(smc_mallows_new_item_rank(n_items, R_obs, leap_size, N, Time, logz_estimate, mcmc_kernel_app, aug_rankings_init, rho_samples_init, alpha_samples_init, alpha, alpha_prop_sd, lambda, alpha_max, aug_method, verbose, alpha_fixed, metric));
     return rcpp_result_gen;
 END_RCPP
 }
 // smc_mallows_new_users
-Rcpp::List smc_mallows_new_users(const arma::mat& R_obs, const std::string& type, const int& n_items, const std::string& metric, const int& leap_size, const int& N, int Time, const int& mcmc_kernel_app, const int& num_new_obs, const double alpha_prop_sd, const double lambda, const double alpha_max, const double alpha, const std::string& aug_method, const Rcpp::Nullable<arma::vec>& logz_estimate, const bool verbose);
-RcppExport SEXP _BayesMallows_smc_mallows_new_users(SEXP R_obsSEXP, SEXP typeSEXP, SEXP n_itemsSEXP, SEXP metricSEXP, SEXP leap_sizeSEXP, SEXP NSEXP, SEXP TimeSEXP, SEXP mcmc_kernel_appSEXP, SEXP num_new_obsSEXP, SEXP alpha_prop_sdSEXP, SEXP lambdaSEXP, SEXP alpha_maxSEXP, SEXP alphaSEXP, SEXP aug_methodSEXP, SEXP logz_estimateSEXP, SEXP verboseSEXP) {
+Rcpp::List smc_mallows_new_users(const arma::mat& R_obs, const std::string& type, const int& n_items, const int& leap_size, const int& N, int Time, const int& mcmc_kernel_app, const int& num_new_obs, const double alpha_prop_sd, const double lambda, const double alpha_max, const double alpha, const std::string& aug_method, const Rcpp::Nullable<arma::vec>& logz_estimate, const bool verbose, const std::string& metric);
+RcppExport SEXP _BayesMallows_smc_mallows_new_users(SEXP R_obsSEXP, SEXP typeSEXP, SEXP n_itemsSEXP, SEXP leap_sizeSEXP, SEXP NSEXP, SEXP TimeSEXP, SEXP mcmc_kernel_appSEXP, SEXP num_new_obsSEXP, SEXP alpha_prop_sdSEXP, SEXP lambdaSEXP, SEXP alpha_maxSEXP, SEXP alphaSEXP, SEXP aug_methodSEXP, SEXP logz_estimateSEXP, SEXP verboseSEXP, SEXP metricSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const arma::mat& >::type R_obs(R_obsSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type type(typeSEXP);
     Rcpp::traits::input_parameter< const int& >::type n_items(n_itemsSEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type metric(metricSEXP);
     Rcpp::traits::input_parameter< const int& >::type leap_size(leap_sizeSEXP);
     Rcpp::traits::input_parameter< const int& >::type N(NSEXP);
     Rcpp::traits::input_parameter< int >::type Time(TimeSEXP);
@@ -323,32 +322,33 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const std::string& >::type aug_method(aug_methodSEXP);
     Rcpp::traits::input_parameter< const Rcpp::Nullable<arma::vec>& >::type logz_estimate(logz_estimateSEXP);
     Rcpp::traits::input_parameter< const bool >::type verbose(verboseSEXP);
-    rcpp_result_gen = Rcpp::wrap(smc_mallows_new_users(R_obs, type, n_items, metric, leap_size, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd, lambda, alpha_max, alpha, aug_method, logz_estimate, verbose));
+    Rcpp::traits::input_parameter< const std::string& >::type metric(metricSEXP);
+    rcpp_result_gen = Rcpp::wrap(smc_mallows_new_users(R_obs, type, n_items, leap_size, N, Time, mcmc_kernel_app, num_new_obs, alpha_prop_sd, lambda, alpha_max, alpha, aug_method, logz_estimate, verbose, metric));
     return rcpp_result_gen;
 END_RCPP
 }
 // metropolis_hastings_alpha
-double metropolis_hastings_alpha(const double alpha, const int n_items, const arma::mat rankings, const std::string metric, const arma::vec rho, const Rcpp::Nullable<arma::vec> logz_estimate, const double alpha_prop_sd, const double lambda, const double alpha_max);
-RcppExport SEXP _BayesMallows_metropolis_hastings_alpha(SEXP alphaSEXP, SEXP n_itemsSEXP, SEXP rankingsSEXP, SEXP metricSEXP, SEXP rhoSEXP, SEXP logz_estimateSEXP, SEXP alpha_prop_sdSEXP, SEXP lambdaSEXP, SEXP alpha_maxSEXP) {
+double metropolis_hastings_alpha(const double alpha, const int n_items, const arma::mat rankings, const arma::vec rho, const Rcpp::Nullable<arma::vec> logz_estimate, const double alpha_prop_sd, const double lambda, const double alpha_max, const std::string metric);
+RcppExport SEXP _BayesMallows_metropolis_hastings_alpha(SEXP alphaSEXP, SEXP n_itemsSEXP, SEXP rankingsSEXP, SEXP rhoSEXP, SEXP logz_estimateSEXP, SEXP alpha_prop_sdSEXP, SEXP lambdaSEXP, SEXP alpha_maxSEXP, SEXP metricSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const double >::type alpha(alphaSEXP);
     Rcpp::traits::input_parameter< const int >::type n_items(n_itemsSEXP);
     Rcpp::traits::input_parameter< const arma::mat >::type rankings(rankingsSEXP);
-    Rcpp::traits::input_parameter< const std::string >::type metric(metricSEXP);
     Rcpp::traits::input_parameter< const arma::vec >::type rho(rhoSEXP);
     Rcpp::traits::input_parameter< const Rcpp::Nullable<arma::vec> >::type logz_estimate(logz_estimateSEXP);
     Rcpp::traits::input_parameter< const double >::type alpha_prop_sd(alpha_prop_sdSEXP);
     Rcpp::traits::input_parameter< const double >::type lambda(lambdaSEXP);
     Rcpp::traits::input_parameter< const double >::type alpha_max(alpha_maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(metropolis_hastings_alpha(alpha, n_items, rankings, metric, rho, logz_estimate, alpha_prop_sd, lambda, alpha_max));
+    Rcpp::traits::input_parameter< const std::string >::type metric(metricSEXP);
+    rcpp_result_gen = Rcpp::wrap(metropolis_hastings_alpha(alpha, n_items, rankings, rho, logz_estimate, alpha_prop_sd, lambda, alpha_max, metric));
     return rcpp_result_gen;
 END_RCPP
 }
 // metropolis_hastings_aug_ranking
-arma::vec metropolis_hastings_aug_ranking(const double& alpha, const arma::vec& rho, const int& n_items, const arma::vec& partial_ranking, const arma::vec& current_ranking, const std::string& metric, const bool& pseudo);
-RcppExport SEXP _BayesMallows_metropolis_hastings_aug_ranking(SEXP alphaSEXP, SEXP rhoSEXP, SEXP n_itemsSEXP, SEXP partial_rankingSEXP, SEXP current_rankingSEXP, SEXP metricSEXP, SEXP pseudoSEXP) {
+arma::vec metropolis_hastings_aug_ranking(const double& alpha, const arma::vec& rho, const int& n_items, const arma::vec& partial_ranking, const arma::vec& current_ranking, const bool& pseudo, const std::string& metric);
+RcppExport SEXP _BayesMallows_metropolis_hastings_aug_ranking(SEXP alphaSEXP, SEXP rhoSEXP, SEXP n_itemsSEXP, SEXP partial_rankingSEXP, SEXP current_rankingSEXP, SEXP pseudoSEXP, SEXP metricSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -357,25 +357,25 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const int& >::type n_items(n_itemsSEXP);
     Rcpp::traits::input_parameter< const arma::vec& >::type partial_ranking(partial_rankingSEXP);
     Rcpp::traits::input_parameter< const arma::vec& >::type current_ranking(current_rankingSEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type metric(metricSEXP);
     Rcpp::traits::input_parameter< const bool& >::type pseudo(pseudoSEXP);
-    rcpp_result_gen = Rcpp::wrap(metropolis_hastings_aug_ranking(alpha, rho, n_items, partial_ranking, current_ranking, metric, pseudo));
+    Rcpp::traits::input_parameter< const std::string& >::type metric(metricSEXP);
+    rcpp_result_gen = Rcpp::wrap(metropolis_hastings_aug_ranking(alpha, rho, n_items, partial_ranking, current_ranking, pseudo, metric));
     return rcpp_result_gen;
 END_RCPP
 }
 // metropolis_hastings_rho
-arma::vec metropolis_hastings_rho(const double alpha, const int n_items, const arma::mat rankings, const std::string metric, const arma::vec rho, const int leap_size);
-RcppExport SEXP _BayesMallows_metropolis_hastings_rho(SEXP alphaSEXP, SEXP n_itemsSEXP, SEXP rankingsSEXP, SEXP metricSEXP, SEXP rhoSEXP, SEXP leap_sizeSEXP) {
+arma::vec metropolis_hastings_rho(const double alpha, const int n_items, const arma::mat rankings, const arma::vec rho, const int leap_size, const std::string metric);
+RcppExport SEXP _BayesMallows_metropolis_hastings_rho(SEXP alphaSEXP, SEXP n_itemsSEXP, SEXP rankingsSEXP, SEXP rhoSEXP, SEXP leap_sizeSEXP, SEXP metricSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const double >::type alpha(alphaSEXP);
     Rcpp::traits::input_parameter< const int >::type n_items(n_itemsSEXP);
     Rcpp::traits::input_parameter< const arma::mat >::type rankings(rankingsSEXP);
-    Rcpp::traits::input_parameter< const std::string >::type metric(metricSEXP);
     Rcpp::traits::input_parameter< const arma::vec >::type rho(rhoSEXP);
     Rcpp::traits::input_parameter< const int >::type leap_size(leap_sizeSEXP);
-    rcpp_result_gen = Rcpp::wrap(metropolis_hastings_rho(alpha, n_items, rankings, metric, rho, leap_size));
+    Rcpp::traits::input_parameter< const std::string >::type metric(metricSEXP);
+    rcpp_result_gen = Rcpp::wrap(metropolis_hastings_rho(alpha, n_items, rankings, rho, leap_size, metric));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -328,8 +328,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // metropolis_hastings_alpha
-double metropolis_hastings_alpha(const double alpha, const int n_items, const arma::mat rankings, const arma::vec rho, const Rcpp::Nullable<arma::vec> logz_estimate, const double lambda, const double alpha_max, const std::string metric, const double alpha_prop_sd);
-RcppExport SEXP _BayesMallows_metropolis_hastings_alpha(SEXP alphaSEXP, SEXP n_itemsSEXP, SEXP rankingsSEXP, SEXP rhoSEXP, SEXP logz_estimateSEXP, SEXP lambdaSEXP, SEXP alpha_maxSEXP, SEXP metricSEXP, SEXP alpha_prop_sdSEXP) {
+double metropolis_hastings_alpha(const double alpha, const int n_items, const arma::mat rankings, const arma::vec rho, const Rcpp::Nullable<arma::vec> logz_estimate, const double lambda, const std::string metric, const double alpha_prop_sd, const double alpha_max);
+RcppExport SEXP _BayesMallows_metropolis_hastings_alpha(SEXP alphaSEXP, SEXP n_itemsSEXP, SEXP rankingsSEXP, SEXP rhoSEXP, SEXP logz_estimateSEXP, SEXP lambdaSEXP, SEXP metricSEXP, SEXP alpha_prop_sdSEXP, SEXP alpha_maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -339,10 +339,10 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const arma::vec >::type rho(rhoSEXP);
     Rcpp::traits::input_parameter< const Rcpp::Nullable<arma::vec> >::type logz_estimate(logz_estimateSEXP);
     Rcpp::traits::input_parameter< const double >::type lambda(lambdaSEXP);
-    Rcpp::traits::input_parameter< const double >::type alpha_max(alpha_maxSEXP);
     Rcpp::traits::input_parameter< const std::string >::type metric(metricSEXP);
     Rcpp::traits::input_parameter< const double >::type alpha_prop_sd(alpha_prop_sdSEXP);
-    rcpp_result_gen = Rcpp::wrap(metropolis_hastings_alpha(alpha, n_items, rankings, rho, logz_estimate, lambda, alpha_max, metric, alpha_prop_sd));
+    Rcpp::traits::input_parameter< const double >::type alpha_max(alpha_maxSEXP);
+    rcpp_result_gen = Rcpp::wrap(metropolis_hastings_alpha(alpha, n_items, rankings, rho, logz_estimate, lambda, metric, alpha_prop_sd, alpha_max));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/smc.h
+++ b/src/smc.h
@@ -7,7 +7,7 @@ arma::vec normalize_weights(const arma::vec& log_inc_wgt);
 arma::vec initialize_alpha(const int& N);
 double get_exponent_sum(double, arma::vec, int, arma::mat, std::string);
 arma::vec metropolis_hastings_rho(double, int, arma::mat, arma::vec, std::string, int);
-double metropolis_hastings_alpha(double, int, arma::mat, arma::vec, const Rcpp::Nullable<arma::vec>, double, double, double, std::string);
+double metropolis_hastings_alpha(double, int, arma::mat, arma::vec, const Rcpp::Nullable<arma::vec>, double, double, std::string, double);
 arma::vec get_sample_probabilities(arma::vec, double, arma::vec, int, std::string);
 Rcpp::List calculate_forward_probability(arma::uvec, arma::vec, arma::vec, arma::vec, double, int, std::string);
 double calculate_backward_probability(arma::uvec, arma::vec, arma::vec, arma::vec, arma::vec, double, int, std::string);

--- a/src/smc.h
+++ b/src/smc.h
@@ -7,7 +7,7 @@ arma::vec normalize_weights(const arma::vec& log_inc_wgt);
 arma::vec initialize_alpha(const int& N);
 double get_exponent_sum(double, arma::vec, int, arma::mat, std::string);
 arma::vec metropolis_hastings_rho(double, int, arma::mat, arma::vec, std::string, int);
-double metropolis_hastings_alpha(double, int, arma::mat, arma::vec, const Rcpp::Nullable<arma::vec>, double, double, std::string, double);
+double metropolis_hastings_alpha(double, int, arma::mat, arma::vec, const Rcpp::Nullable<arma::vec>, double, std::string, double, double);
 arma::vec get_sample_probabilities(arma::vec, double, arma::vec, int, std::string);
 Rcpp::List calculate_forward_probability(arma::uvec, arma::vec, arma::vec, arma::vec, double, int, std::string);
 double calculate_backward_probability(arma::uvec, arma::vec, arma::vec, arma::vec, arma::vec, double, int, std::string);

--- a/src/smc.h
+++ b/src/smc.h
@@ -6,12 +6,12 @@
 arma::vec normalize_weights(const arma::vec& log_inc_wgt);
 arma::vec initialize_alpha(const int& N);
 double get_exponent_sum(double, arma::vec, int, arma::mat, std::string);
-arma::vec metropolis_hastings_rho(double, int, arma::mat, std::string, arma::vec, int);
-double metropolis_hastings_alpha(double, int, arma::mat, std::string, arma::vec, const Rcpp::Nullable<arma::vec>, double, double, double);
-arma::vec get_sample_probabilities(arma::vec, double, arma::vec, std::string, int);
+arma::vec metropolis_hastings_rho(double, int, arma::mat, arma::vec, int, std::string);
+double metropolis_hastings_alpha(double, int, arma::mat, arma::vec, const Rcpp::Nullable<arma::vec>, double, double, double, std::string);
+arma::vec get_sample_probabilities(arma::vec, double, arma::vec, int, std::string);
 Rcpp::List calculate_forward_probability(arma::uvec, arma::vec, arma::vec, arma::vec, double, int, std::string);
 double calculate_backward_probability(arma::uvec, arma::vec, arma::vec, arma::vec, arma::vec, double, int, std::string);
 Rcpp::List correction_kernel(arma::vec, arma::vec, int);
 Rcpp::List correction_kernel_pseudo(arma::vec, arma::vec, arma::vec, double, int, std::string);
-arma::vec metropolis_hastings_aug_ranking(const double&, const arma::vec&, const int&, const arma::vec&, const arma::vec&, const std::string&, const bool&);
+arma::vec metropolis_hastings_aug_ranking(const double&, const arma::vec&, const int&, const arma::vec&, const arma::vec&, const bool&, const std::string&);
 #endif

--- a/src/smc.h
+++ b/src/smc.h
@@ -7,7 +7,7 @@ arma::vec normalize_weights(const arma::vec& log_inc_wgt);
 arma::vec initialize_alpha(const int& N);
 double get_exponent_sum(double, arma::vec, int, arma::mat, std::string);
 arma::vec metropolis_hastings_rho(double, int, arma::mat, arma::vec, std::string, int);
-double metropolis_hastings_alpha(double, int, arma::mat, arma::vec, const Rcpp::Nullable<arma::vec>, double, std::string, double, double);
+double metropolis_hastings_alpha(double, int, arma::mat, arma::vec, const Rcpp::Nullable<arma::vec>, std::string, double, double, double);
 arma::vec get_sample_probabilities(arma::vec, double, arma::vec, int, std::string);
 Rcpp::List calculate_forward_probability(arma::uvec, arma::vec, arma::vec, arma::vec, double, int, std::string);
 double calculate_backward_probability(arma::uvec, arma::vec, arma::vec, arma::vec, arma::vec, double, int, std::string);

--- a/src/smc.h
+++ b/src/smc.h
@@ -6,7 +6,7 @@
 arma::vec normalize_weights(const arma::vec& log_inc_wgt);
 arma::vec initialize_alpha(const int& N);
 double get_exponent_sum(double, arma::vec, int, arma::mat, std::string);
-arma::vec metropolis_hastings_rho(double, int, arma::mat, arma::vec, int, std::string);
+arma::vec metropolis_hastings_rho(double, int, arma::mat, arma::vec, std::string, int);
 double metropolis_hastings_alpha(double, int, arma::mat, arma::vec, const Rcpp::Nullable<arma::vec>, double, double, double, std::string);
 arma::vec get_sample_probabilities(arma::vec, double, arma::vec, int, std::string);
 Rcpp::List calculate_forward_probability(arma::uvec, arma::vec, arma::vec, arma::vec, double, int, std::string);

--- a/src/smc_calculate_probability.cpp
+++ b/src/smc_calculate_probability.cpp
@@ -16,8 +16,8 @@ double smc_calculate_probability(
   const uword& num_items_unranked,
   const double& alpha,
   const int& n_items,
-  const std::string& metric,
-  const bool& forward
+  const bool& forward,
+  const std::string& metric = "footrule"
 ) {
   for (uword jj = 0; jj < num_items_unranked - 1; ++jj) {
     // items to sample rank
@@ -30,7 +30,7 @@ double smc_calculate_probability(
     // next we get the sample probabilites for selecting a particular rank for
     // an item based on the current alpha and the rho rank for that item
     vec sample_prob_list = get_sample_probabilities(
-      rho_item_rank, alpha, remaining_set, metric, n_items
+      rho_item_rank, alpha, remaining_set, n_items, metric
     );
 
     // fill in the new augmented ranking going forward
@@ -80,7 +80,7 @@ double calculate_backward_probability(
     const arma::vec rho,
     const double alpha,
     const int n_items,
-    const std::string metric
+    const std::string metric = "footrule"
 ) {
   // given an old and new item ordering, sample ranking with new ordering and
   // calc the forward and backward prob
@@ -108,7 +108,7 @@ double calculate_backward_probability(
     backward_auxiliary_ranking_probability =
     smc_calculate_probability(
       backward_auxiliary_ranking_probability, remaining_set, item_ordering,
-      current_ranking, rho, num_items_unranked, alpha, n_items, metric, false
+      current_ranking, rho, num_items_unranked, alpha, n_items, false, metric
     );
   }
   return backward_auxiliary_ranking_probability;
@@ -146,7 +146,7 @@ Rcpp::List calculate_forward_probability(
     const arma::vec rho,
     const double alpha,
     const int n_items,
-    const std::string metric
+    const std::string metric = "footrule"
 ) {
   // item ordering is the order of which items are assigned ranks in a specified
   // order
@@ -173,7 +173,7 @@ Rcpp::List calculate_forward_probability(
 
     forward_auxiliary_ranking_probability = smc_calculate_probability(
       forward_auxiliary_ranking_probability, remaining_set, item_ordering,
-      auxiliary_ranking, rho, num_items_unranked, alpha, n_items, metric, true
+      auxiliary_ranking, rho, num_items_unranked, alpha, n_items, true, metric
     );
     // last element in augmented ranking is deterministic - the prob is 1
     auxiliary_ranking(num_items_unranked - 1) = as_scalar(remaining_set);

--- a/src/smc_correction_kernel_pseudo.cpp
+++ b/src/smc_correction_kernel_pseudo.cpp
@@ -29,7 +29,7 @@ Rcpp::List correction_kernel_pseudo(
     const arma::vec rho,
     const double alpha,
     const int n_items,
-    const std::string metric
+    const std::string metric = "footrule"
 ) {
     bool observed_equals_current = approx_equal(\
         observed_ranking, current_ranking, "absdiff", 0.1\
@@ -78,7 +78,7 @@ Rcpp::List correction_kernel_pseudo(
                 // next we get the sample probabilites for selecting a particular rank for
                 // an item based on the current alpha and the rho rank for that item
                 const vec sample_prob_list = get_sample_probabilities(\
-                    rho_item_rank, alpha, remaining_set, metric, n_items\
+                    rho_item_rank, alpha, remaining_set, n_items, metric\
                 );
 
                 // fill in the new augmented ranking going forward

--- a/src/smc_get_exponent_sum.cpp
+++ b/src/smc_get_exponent_sum.cpp
@@ -55,7 +55,7 @@ double get_exponent_sum(
   const arma::vec rho,
   const int n_items,
   arma::mat rankings,
-  const std::string metric
+  const std::string metric = "footrule"
 ) {
   /* Transpose matrices as needed ------------------------- */
   if (rho.n_rows == rankings.n_cols) {

--- a/src/smc_get_sample_probabilities.cpp
+++ b/src/smc_get_sample_probabilities.cpp
@@ -25,8 +25,8 @@ arma::vec get_sample_probabilities(
   const arma::vec rho_item_rank,
   const double alpha,
   const arma::vec remaining_set_ranks,
-  const std::string metric,
-  const int n_items
+  const int n_items,
+  const std::string metric = "footrule"
 ) {
   // define a set of probs list
   const unsigned int& num_ranks = remaining_set_ranks.n_elem;

--- a/src/smc_leap_and_shift_probs.cpp
+++ b/src/smc_leap_and_shift_probs.cpp
@@ -23,12 +23,12 @@ using namespace arma;
 //' rho <- c(1, 2, 3, 4, 5, 6)
 //' n_items <- 6
 //'
-//' leap_and_shift_probs(rho, 1, n_items)
-//' leap_and_shift_probs(rho, 2, n_items)
-//' leap_and_shift_probs(rho, 3, n_items)
+//' leap_and_shift_probs(rho, n_items, 1)
+//' leap_and_shift_probs(rho, n_items, 2)
+//' leap_and_shift_probs(rho, n_items, 3)
 //'
 // [[Rcpp::export]]
-Rcpp::List leap_and_shift_probs(const arma::vec rho, const int leap_size, const int n_items) {
+Rcpp::List leap_and_shift_probs(const arma::vec rho, const int n_items, const int leap_size = 1) {
   vec rho_proposal{};
   uvec indices{};
   double prob_forward, prob_backward;

--- a/src/smc_mallows_new_item_rank.cpp
+++ b/src/smc_mallows_new_item_rank.cpp
@@ -17,13 +17,13 @@ void new_items_move_step(
     const std::string& aug_method,
     const Rcpp::Nullable<arma::vec>& logz_estimate,
     const double& alpha,
-    const double& alpha_prop_sd,
     const double& lambda,
     const double& alpha_max,
     const uword& ttplus1,
     const bool& alpha_fixed,
     const std::string& metric = "footrule",
-    const int& leap_size = 1
+    const int& leap_size = 1,
+    const double& alpha_prop_sd = 0.5
 ){
   const uword num_ranks = R_obs.n_rows;
   const uword N = rho_samples.n_rows;
@@ -37,7 +37,7 @@ void new_items_move_step(
       alpha_samples(ii, ttplus1) = metropolis_hastings_alpha(
         alpha_samples(ii, ttplus1), n_items, aug_rankings.slice(ii),
         rho_samples.slice(ttplus1).row(ii).t(), logz_estimate,
-        alpha_prop_sd, lambda, alpha_max, metric
+        lambda, alpha_max, metric, alpha_prop_sd
       );
     }
 
@@ -158,7 +158,7 @@ Rcpp::List smc_mallows_new_item_rank(
   Rcpp::Nullable<arma::mat> rho_samples_init = R_NilValue,
   arma::vec alpha_samples_init = 0,
   const double alpha = 0,
-  const double alpha_prop_sd = 1,
+  const double alpha_prop_sd = 0.5,
   const double lambda = 1,
   const double alpha_max = 1,
   const std::string& aug_method = "random",
@@ -313,8 +313,8 @@ Rcpp::List smc_mallows_new_item_rank(
     /* ====================================================== */
     new_items_move_step(
       rho_samples, alpha_samples, aug_rankings, R_obs, aug_method,
-      logz_estimate, alpha, alpha_prop_sd, lambda, alpha_max, tt + 1,
-      alpha_fixed, metric, leap_size);
+      logz_estimate, alpha, lambda, alpha_max, tt + 1,
+      alpha_fixed, metric, leap_size, alpha_prop_sd);
   }
 
   /* ====================================================== */

--- a/src/smc_mallows_new_item_rank.cpp
+++ b/src/smc_mallows_new_item_rank.cpp
@@ -18,12 +18,12 @@ void new_items_move_step(
     const Rcpp::Nullable<arma::vec>& logz_estimate,
     const double& alpha,
     const double& lambda,
-    const double& alpha_max,
     const uword& ttplus1,
     const bool& alpha_fixed,
     const std::string& metric = "footrule",
     const int& leap_size = 1,
-    const double& alpha_prop_sd = 0.5
+    const double& alpha_prop_sd = 0.5,
+    const double& alpha_max = 1e6
 ){
   const uword num_ranks = R_obs.n_rows;
   const uword N = rho_samples.n_rows;
@@ -37,7 +37,7 @@ void new_items_move_step(
       alpha_samples(ii, ttplus1) = metropolis_hastings_alpha(
         alpha_samples(ii, ttplus1), n_items, aug_rankings.slice(ii),
         rho_samples.slice(ttplus1).row(ii).t(), logz_estimate,
-        lambda, alpha_max, metric, alpha_prop_sd
+        lambda, metric, alpha_prop_sd, alpha_max
       );
     }
 
@@ -160,7 +160,7 @@ Rcpp::List smc_mallows_new_item_rank(
   const double alpha = 0,
   const double alpha_prop_sd = 0.5,
   const double lambda = 1,
-  const double alpha_max = 1,
+  const double alpha_max = 1e6,
   const std::string& aug_method = "random",
   const bool verbose = false,
   const bool alpha_fixed = false,
@@ -313,8 +313,8 @@ Rcpp::List smc_mallows_new_item_rank(
     /* ====================================================== */
     new_items_move_step(
       rho_samples, alpha_samples, aug_rankings, R_obs, aug_method,
-      logz_estimate, alpha, lambda, alpha_max, tt + 1,
-      alpha_fixed, metric, leap_size, alpha_prop_sd);
+      logz_estimate, alpha, lambda, tt + 1,
+      alpha_fixed, metric, leap_size, alpha_prop_sd, alpha_max);
   }
 
   /* ====================================================== */

--- a/src/smc_mallows_new_item_rank.cpp
+++ b/src/smc_mallows_new_item_rank.cpp
@@ -21,9 +21,9 @@ void new_items_move_step(
     const double& lambda,
     const double& alpha_max,
     const uword& ttplus1,
-    const int& leap_size,
     const bool& alpha_fixed,
-    const std::string& metric = "footrule"
+    const std::string& metric = "footrule",
+    const int& leap_size = 1
 ){
   const uword num_ranks = R_obs.n_rows;
   const uword N = rho_samples.n_rows;
@@ -31,7 +31,7 @@ void new_items_move_step(
   for (uword ii = 0; ii < N; ++ii) {
     rho_samples.slice(ttplus1).row(ii) = metropolis_hastings_rho(
       alpha_fixed ? alpha : alpha_samples(ii, ttplus1), n_items, aug_rankings.slice(ii),
-      rho_samples.slice(ttplus1).row(ii).t(), leap_size, metric
+      rho_samples.slice(ttplus1).row(ii).t(), metric, leap_size
     ).t();
     if(!alpha_fixed){
       alpha_samples(ii, ttplus1) = metropolis_hastings_alpha(
@@ -150,7 +150,6 @@ arma::cube augment_rankings(
 Rcpp::List smc_mallows_new_item_rank(
   const unsigned int& n_items,
   arma::cube& R_obs,
-  const int& leap_size,
   const unsigned int& N,
   const unsigned int Time,
   const Rcpp::Nullable<arma::vec> logz_estimate,
@@ -165,7 +164,8 @@ Rcpp::List smc_mallows_new_item_rank(
   const std::string& aug_method = "random",
   const bool verbose = false,
   const bool alpha_fixed = false,
-  const std::string& metric = "footrule"
+  const std::string& metric = "footrule",
+  const int& leap_size = 1
 ) {
   /* ====================================================== */
   /* Initialise Phase                                       */
@@ -313,8 +313,8 @@ Rcpp::List smc_mallows_new_item_rank(
     /* ====================================================== */
     new_items_move_step(
       rho_samples, alpha_samples, aug_rankings, R_obs, aug_method,
-      logz_estimate, alpha, alpha_prop_sd, lambda, alpha_max, tt + 1, leap_size,
-      alpha_fixed, metric);
+      logz_estimate, alpha, alpha_prop_sd, lambda, alpha_max, tt + 1,
+      alpha_fixed, metric, leap_size);
   }
 
   /* ====================================================== */

--- a/src/smc_mallows_new_item_rank.cpp
+++ b/src/smc_mallows_new_item_rank.cpp
@@ -17,13 +17,13 @@ void new_items_move_step(
     const std::string& aug_method,
     const Rcpp::Nullable<arma::vec>& logz_estimate,
     const double& alpha,
-    const double& lambda,
     const uword& ttplus1,
     const bool& alpha_fixed,
     const std::string& metric = "footrule",
     const int& leap_size = 1,
     const double& alpha_prop_sd = 0.5,
-    const double& alpha_max = 1e6
+    const double& alpha_max = 1e6,
+    const double& lambda = 0.1
 ){
   const uword num_ranks = R_obs.n_rows;
   const uword N = rho_samples.n_rows;
@@ -37,7 +37,7 @@ void new_items_move_step(
       alpha_samples(ii, ttplus1) = metropolis_hastings_alpha(
         alpha_samples(ii, ttplus1), n_items, aug_rankings.slice(ii),
         rho_samples.slice(ttplus1).row(ii).t(), logz_estimate,
-        lambda, metric, alpha_prop_sd, alpha_max
+        metric, alpha_prop_sd, alpha_max, lambda
       );
     }
 
@@ -159,7 +159,7 @@ Rcpp::List smc_mallows_new_item_rank(
   arma::vec alpha_samples_init = 0,
   const double alpha = 0,
   const double alpha_prop_sd = 0.5,
-  const double lambda = 1,
+  const double lambda = 0.1,
   const double alpha_max = 1e6,
   const std::string& aug_method = "random",
   const bool verbose = false,
@@ -313,8 +313,8 @@ Rcpp::List smc_mallows_new_item_rank(
     /* ====================================================== */
     new_items_move_step(
       rho_samples, alpha_samples, aug_rankings, R_obs, aug_method,
-      logz_estimate, alpha, lambda, tt + 1,
-      alpha_fixed, metric, leap_size, alpha_prop_sd, alpha_max);
+      logz_estimate, alpha, tt + 1,
+      alpha_fixed, metric, leap_size, alpha_prop_sd, alpha_max, lambda);
   }
 
   /* ====================================================== */

--- a/src/smc_mallows_new_users.cpp
+++ b/src/smc_mallows_new_users.cpp
@@ -64,7 +64,7 @@ Rcpp::List smc_mallows_new_users(
   const int& mcmc_kernel_app,
   const int& num_new_obs,
   const double alpha_prop_sd = 0.5,
-  const double lambda = 1,
+  const double lambda = 0.1,
   const double alpha_max = 1e6,
   const double alpha = 0,
   const std::string& aug_method = "random",
@@ -184,7 +184,7 @@ Rcpp::List smc_mallows_new_users(
             );
           alpha_samples(ii, tt + 1) = metropolis_hastings_alpha(              \
             as, n_items, all_observed_rankings, rs.t(), logz_estimate,\
-            lambda, metric, alpha_prop_sd, alpha_max\
+            metric, alpha_prop_sd, alpha_max, lambda\
           );
         }
       } else if(type == "partial" || type == "partial_alpha_fixed"){
@@ -203,7 +203,7 @@ Rcpp::List smc_mallows_new_users(
             if(type == "partial"){
               alpha_samples(ii, tt + 1) = metropolis_hastings_alpha(\
                 as, n_items, all_observed_rankings, rs.t(), logz_estimate,\
-                lambda, metric, alpha_prop_sd, alpha_max\
+                metric, alpha_prop_sd, alpha_max, lambda\
               );
             }
             for (uword jj = num_obs - num_new_obs; jj < num_obs; ++jj) {

--- a/src/smc_mallows_new_users.cpp
+++ b/src/smc_mallows_new_users.cpp
@@ -65,7 +65,7 @@ Rcpp::List smc_mallows_new_users(
   const int& num_new_obs,
   const double alpha_prop_sd = 0.5,
   const double lambda = 1,
-  const double alpha_max = 1,
+  const double alpha_max = 1e6,
   const double alpha = 0,
   const std::string& aug_method = "random",
   const Rcpp::Nullable<arma::vec>& logz_estimate = R_NilValue,
@@ -184,7 +184,7 @@ Rcpp::List smc_mallows_new_users(
             );
           alpha_samples(ii, tt + 1) = metropolis_hastings_alpha(              \
             as, n_items, all_observed_rankings, rs.t(), logz_estimate,\
-            lambda, alpha_max, metric, alpha_prop_sd\
+            lambda, metric, alpha_prop_sd, alpha_max\
           );
         }
       } else if(type == "partial" || type == "partial_alpha_fixed"){
@@ -203,7 +203,7 @@ Rcpp::List smc_mallows_new_users(
             if(type == "partial"){
               alpha_samples(ii, tt + 1) = metropolis_hastings_alpha(\
                 as, n_items, all_observed_rankings, rs.t(), logz_estimate,\
-                lambda, alpha_max, metric, alpha_prop_sd\
+                lambda, metric, alpha_prop_sd, alpha_max\
               );
             }
             for (uword jj = num_obs - num_new_obs; jj < num_obs; ++jj) {

--- a/src/smc_mallows_new_users.cpp
+++ b/src/smc_mallows_new_users.cpp
@@ -59,7 +59,6 @@ Rcpp::List smc_mallows_new_users(
   const arma::mat& R_obs,
   const std::string& type,
   const int& n_items,
-  const int& leap_size,
   const int& N,
   int Time,
   const int& mcmc_kernel_app,
@@ -71,7 +70,8 @@ Rcpp::List smc_mallows_new_users(
   const std::string& aug_method = "random",
   const Rcpp::Nullable<arma::vec>& logz_estimate = R_NilValue,
   const bool verbose = false,
-  const std::string& metric = "footnote"
+  const std::string& metric = "footnote",
+  const int& leap_size = 1
 ) {
   /* ====================================================== */
   /* Initialise Phase                                       */
@@ -180,7 +180,7 @@ Rcpp::List smc_mallows_new_users(
             rho_samples(span(ii), span::all, span(tt + 1));
           rho_samples(span(ii), span::all, span(tt + 1)) =                 \
             metropolis_hastings_rho(                                       \
-              as, n_items, all_observed_rankings, rs.t(), leap_size, metric\
+              as, n_items, all_observed_rankings, rs.t(), metric, leap_size\
             );
           alpha_samples(ii, tt + 1) = metropolis_hastings_alpha(              \
             as, n_items, all_observed_rankings, rs.t(), logz_estimate,\
@@ -198,7 +198,7 @@ Rcpp::List smc_mallows_new_users(
             // the MCMC kernels
             rho_samples(span(ii), span::all, span(tt + 1)) =                 \
               metropolis_hastings_rho(                                       \
-                as, n_items, all_observed_rankings, rs.t(), leap_size, metric\
+                as, n_items, all_observed_rankings, rs.t(), metric, leap_size\
               );
             if(type == "partial"){
               alpha_samples(ii, tt + 1) = metropolis_hastings_alpha(\

--- a/src/smc_mallows_new_users.cpp
+++ b/src/smc_mallows_new_users.cpp
@@ -59,7 +59,6 @@ Rcpp::List smc_mallows_new_users(
   const arma::mat& R_obs,
   const std::string& type,
   const int& n_items,
-  const std::string& metric,
   const int& leap_size,
   const int& N,
   int Time,
@@ -71,7 +70,8 @@ Rcpp::List smc_mallows_new_users(
   const double alpha = 0,
   const std::string& aug_method = "random",
   const Rcpp::Nullable<arma::vec>& logz_estimate = R_NilValue,
-  const bool verbose = false
+  const bool verbose = false,
+  const std::string& metric = "footnote"
 ) {
   /* ====================================================== */
   /* Initialise Phase                                       */
@@ -143,7 +143,7 @@ Rcpp::List smc_mallows_new_users(
     if(type == "partial" || type == "partial_alpha_fixed"){
       smc_mallows_new_users_augment_partial(
         aug_rankings, aug_prob, rho_samples, alpha_samples, num_obs, num_new_obs,
-        R_obs, aug_method, metric, tt, alpha, type != "partial_alpha_fixed");
+        R_obs, aug_method, tt, alpha, type != "partial_alpha_fixed", metric);
     }
 
     /* ====================================================== */
@@ -156,8 +156,8 @@ Rcpp::List smc_mallows_new_users(
     vec norm_wgt;
     smc_mallows_new_users_reweight(
       log_inc_wgt, ESS_vec, norm_wgt, aug_rankings, new_observed_rankings, rho_samples,
-      alpha, alpha_samples, tt, logz_estimate, metric, num_obs,
-      num_new_obs, ones(N), type != "partial_alpha_fixed", type != "complete");
+      alpha, alpha_samples, tt, logz_estimate, num_obs, num_new_obs, ones(N),
+      type != "partial_alpha_fixed", type != "complete", metric);
 
     /* ====================================================== */
     /* Resample                                               */
@@ -180,11 +180,11 @@ Rcpp::List smc_mallows_new_users(
             rho_samples(span(ii), span::all, span(tt + 1));
           rho_samples(span(ii), span::all, span(tt + 1)) =                 \
             metropolis_hastings_rho(                                       \
-              as, n_items, all_observed_rankings, metric, rs.t(), leap_size\
+              as, n_items, all_observed_rankings, rs.t(), leap_size, metric\
             );
           alpha_samples(ii, tt + 1) = metropolis_hastings_alpha(              \
-            as, n_items, all_observed_rankings, metric, rs.t(), logz_estimate,\
-            alpha_prop_sd, lambda, alpha_max                                  \
+            as, n_items, all_observed_rankings, rs.t(), logz_estimate,\
+            alpha_prop_sd, lambda, alpha_max, metric\
           );
         }
       } else if(type == "partial" || type == "partial_alpha_fixed"){
@@ -198,12 +198,12 @@ Rcpp::List smc_mallows_new_users(
             // the MCMC kernels
             rho_samples(span(ii), span::all, span(tt + 1)) =                 \
               metropolis_hastings_rho(                                       \
-                as, n_items, all_observed_rankings, metric, rs.t(), leap_size\
+                as, n_items, all_observed_rankings, rs.t(), leap_size, metric\
               );
             if(type == "partial"){
-              alpha_samples(ii, tt + 1) = metropolis_hastings_alpha(              \
-                as, n_items, all_observed_rankings, metric, rs.t(), logz_estimate,\
-                alpha_prop_sd, lambda, alpha_max                                  \
+              alpha_samples(ii, tt + 1) = metropolis_hastings_alpha(\
+                as, n_items, all_observed_rankings, rs.t(), logz_estimate,\
+                alpha_prop_sd, lambda, alpha_max, metric\
               );
             }
             for (uword jj = num_obs - num_new_obs; jj < num_obs; ++jj) {
@@ -211,9 +211,9 @@ Rcpp::List smc_mallows_new_users(
               ar = aug_rankings(span(jj), span::all, span(ii));
               vec mh_aug_result;
               if (aug_method == "random") {
-                mh_aug_result = metropolis_hastings_aug_ranking(as, rs.t(), n_items, R_obs.row(jj).t(), ar.t(), metric, false);
+                mh_aug_result = metropolis_hastings_aug_ranking(as, rs.t(), n_items, R_obs.row(jj).t(), ar.t(), false, metric);
               } else if ((aug_method == "pseudolikelihood") && ((metric == "footrule") || (metric == "spearman"))) {
-                mh_aug_result = metropolis_hastings_aug_ranking(as, rs.t(), n_items, R_obs.row(jj).t(), ar.t(), metric, true);
+                mh_aug_result = metropolis_hastings_aug_ranking(as, rs.t(), n_items, R_obs.row(jj).t(), ar.t(), true, metric);
               }
               aug_rankings(span(jj), span::all, span(ii)) = mh_aug_result;
             }

--- a/src/smc_mallows_new_users.cpp
+++ b/src/smc_mallows_new_users.cpp
@@ -63,7 +63,7 @@ Rcpp::List smc_mallows_new_users(
   int Time,
   const int& mcmc_kernel_app,
   const int& num_new_obs,
-  const double alpha_prop_sd = 1,
+  const double alpha_prop_sd = 0.5,
   const double lambda = 1,
   const double alpha_max = 1,
   const double alpha = 0,
@@ -184,7 +184,7 @@ Rcpp::List smc_mallows_new_users(
             );
           alpha_samples(ii, tt + 1) = metropolis_hastings_alpha(              \
             as, n_items, all_observed_rankings, rs.t(), logz_estimate,\
-            alpha_prop_sd, lambda, alpha_max, metric\
+            lambda, alpha_max, metric, alpha_prop_sd\
           );
         }
       } else if(type == "partial" || type == "partial_alpha_fixed"){
@@ -203,7 +203,7 @@ Rcpp::List smc_mallows_new_users(
             if(type == "partial"){
               alpha_samples(ii, tt + 1) = metropolis_hastings_alpha(\
                 as, n_items, all_observed_rankings, rs.t(), logz_estimate,\
-                alpha_prop_sd, lambda, alpha_max, metric\
+                lambda, alpha_max, metric, alpha_prop_sd\
               );
             }
             for (uword jj = num_obs - num_new_obs; jj < num_obs; ++jj) {

--- a/src/smc_mallows_new_users.h
+++ b/src/smc_mallows_new_users.h
@@ -5,13 +5,14 @@
 
 void smc_mallows_new_users_augment_partial(arma::cube&, arma::vec&,
     const arma::cube&, const arma::mat&, const int&, const int&,
-    const arma::mat&, const std::string&, const std::string&, const int&,
-    const double&, const bool&);
+    const arma::mat&, const std::string&, const int&, const double&,
+    const bool&, const std::string&);
 void smc_mallows_new_users_reweight(
     arma::vec&, arma::rowvec&, arma::vec&,
     const arma::cube&, const arma::mat&, const arma::cube&, const double&,
-    const arma::mat&, const int&, const Rcpp::Nullable<arma::vec>, const std::string&,
-    const int&, const int&, const arma::vec&, const bool&, const bool&);
+    const arma::mat&, const int&, const Rcpp::Nullable<arma::vec>,
+    const int&, const int&, const arma::vec&, const bool&, const bool&,
+    const std::string&);
 void smc_mallows_new_users_resample(
     arma::cube&, arma::mat&, arma::cube&, const arma::vec&, const int& tt,
     const int& num_obs, const bool& augment_alpha, const bool& partial);

--- a/src/smc_mallows_new_users_funs.cpp
+++ b/src/smc_mallows_new_users_funs.cpp
@@ -18,10 +18,10 @@ void smc_mallows_new_users_augment_partial(
     const int& num_new_obs,
     const arma::mat& R_obs,
     const std::string& aug_method,
-    const std::string& metric,
     const int& tt,
     const double& alpha,
-    const bool& augment_alpha
+    const bool& augment_alpha,
+    const std::string& metric = "footrule"
 ){
   int N = rho_samples.n_rows;
   int n_items = rho_samples.n_cols;
@@ -106,12 +106,12 @@ void smc_mallows_new_users_reweight(
     const mat& alpha_samples,
     const int& tt,
     const Rcpp::Nullable<vec> logz_estimate,
-    const std::string& metric,
     const int& num_obs,
     const int& num_new_obs,
     const vec& aug_prob,
     const bool& augment_alpha,
-    const bool& partial
+    const bool& partial,
+    const std::string& metric = "footrule"
 ){
   int N = rho_samples.n_rows;
   int n_items = rho_samples.n_cols;

--- a/src/smc_metropolis_hastings_alpha.cpp
+++ b/src/smc_metropolis_hastings_alpha.cpp
@@ -45,10 +45,10 @@ double metropolis_hastings_alpha(
   const arma::mat rankings,
   const arma::vec rho,
   const Rcpp::Nullable<arma::vec> logz_estimate,
-  const double lambda,
   const std::string metric = "footrule",
   const double alpha_prop_sd = 0.5,
-  const double alpha_max = 1e6
+  const double alpha_max = 1e6,
+  const double lambda = 0.1
 ) {
   const double rand = R::rnorm(0, 1);
   const double alpha_prime_log = rand * alpha_prop_sd + std::log(alpha);

--- a/src/smc_metropolis_hastings_alpha.cpp
+++ b/src/smc_metropolis_hastings_alpha.cpp
@@ -46,9 +46,9 @@ double metropolis_hastings_alpha(
   const arma::vec rho,
   const Rcpp::Nullable<arma::vec> logz_estimate,
   const double lambda,
-  const double alpha_max,
   const std::string metric = "footrule",
-  const double alpha_prop_sd = 0.5
+  const double alpha_prop_sd = 0.5,
+  const double alpha_max = 1e6
 ) {
   const double rand = R::rnorm(0, 1);
   const double alpha_prime_log = rand * alpha_prop_sd + std::log(alpha);

--- a/src/smc_metropolis_hastings_alpha.cpp
+++ b/src/smc_metropolis_hastings_alpha.cpp
@@ -43,12 +43,12 @@ double metropolis_hastings_alpha(
   const double alpha,
   const int n_items,
   const arma::mat rankings,
-  const std::string metric,
   const arma::vec rho,
   const Rcpp::Nullable<arma::vec> logz_estimate,
   const double alpha_prop_sd,
   const double lambda,
-  const double alpha_max
+  const double alpha_max,
+  const std::string metric = "footrule"
 ) {
   const double rand = R::rnorm(0, 1);
   const double alpha_prime_log = rand * alpha_prop_sd + std::log(alpha);

--- a/src/smc_metropolis_hastings_alpha.cpp
+++ b/src/smc_metropolis_hastings_alpha.cpp
@@ -45,10 +45,10 @@ double metropolis_hastings_alpha(
   const arma::mat rankings,
   const arma::vec rho,
   const Rcpp::Nullable<arma::vec> logz_estimate,
-  const double alpha_prop_sd,
   const double lambda,
   const double alpha_max,
-  const std::string metric = "footrule"
+  const std::string metric = "footrule",
+  const double alpha_prop_sd = 0.5
 ) {
   const double rand = R::rnorm(0, 1);
   const double alpha_prime_log = rand * alpha_prop_sd + std::log(alpha);

--- a/src/smc_metropolis_hastings_aug_ranking.cpp
+++ b/src/smc_metropolis_hastings_aug_ranking.cpp
@@ -29,8 +29,8 @@ arma::vec metropolis_hastings_aug_ranking(
 	const int& n_items,
 	const arma::vec& partial_ranking,
 	const arma::vec& current_ranking,
-	const std::string& metric,
-	const bool& pseudo
+	const bool& pseudo,
+	const std::string& metric = "footnote"
 ) {
   double forward_backward_prob{};
   vec proposed_ranking;

--- a/src/smc_metropolis_hastings_rho.cpp
+++ b/src/smc_metropolis_hastings_rho.cpp
@@ -47,8 +47,8 @@ arma::vec metropolis_hastings_rho(
 	const int n_items,
 	const arma::mat rankings,
 	const arma::vec rho,
-	const int leap_size,
-	const std::string metric = "footnote"
+	const std::string metric = "footnote",
+	const int leap_size = 1
 ) {
   // create new potential consensus ranking
   vec rho_proposal{};

--- a/src/smc_metropolis_hastings_rho.cpp
+++ b/src/smc_metropolis_hastings_rho.cpp
@@ -46,9 +46,9 @@ arma::vec metropolis_hastings_rho(
 	const double alpha,
 	const int n_items,
 	const arma::mat rankings,
-	const std::string metric,
 	const arma::vec rho,
-	const int leap_size
+	const int leap_size,
+	const std::string metric = "footnote"
 ) {
   // create new potential consensus ranking
   vec rho_proposal{};

--- a/tests/testthat/test-bulletproofing.R
+++ b/tests/testthat/test-bulletproofing.R
@@ -38,9 +38,9 @@ test_that("Functions accept rankings and rho as row or column vectors", {
     rho = rho_init,
     logz_estimate,
     lambda,
-    alpha_max,
     metric,
-    alpha_prop_sd
+    alpha_prop_sd,
+    alpha_max
   )
   mhr_rt_r <- metropolis_hastings_rho(
     alpha_init, n_items,
@@ -55,9 +55,9 @@ test_that("Functions accept rankings and rho as row or column vectors", {
     rho = rho_init,
     logz_estimate,
     lambda,
-    alpha_max,
     metric,
-    alpha_prop_sd
+    alpha_prop_sd,
+    alpha_max
   )
   mhr_r_rt <- metropolis_hastings_rho(
     alpha_init, n_items,
@@ -72,9 +72,9 @@ test_that("Functions accept rankings and rho as row or column vectors", {
     rho = t(rho_init),
     logz_estimate,
     lambda,
-    alpha_max,
     metric,
-    alpha_prop_sd
+    alpha_prop_sd,
+    alpha_max
   )
   mhr_rt_rt <- metropolis_hastings_rho(
     alpha_init, n_items,
@@ -89,9 +89,9 @@ test_that("Functions accept rankings and rho as row or column vectors", {
     rho = t(rho_init),
     logz_estimate,
     lambda,
-    alpha_max,
     metric,
-    alpha_prop_sd
+    alpha_prop_sd,
+    alpha_max
   )
   expect_equal(dim(mhr_r_r), c(10, 1))
   expect_length(mha_r_r, 1)

--- a/tests/testthat/test-bulletproofing.R
+++ b/tests/testthat/test-bulletproofing.R
@@ -29,8 +29,8 @@ test_that("Functions accept rankings and rho as row or column vectors", {
     alpha_init, n_items,
     rankings = as.matrix(cluster_rankings),
     rho = rho_init,
-    leap_size,
-    metric
+    metric,
+    leap_size
   )
   mha_r_r <- metropolis_hastings_alpha(
     alpha_init, n_items,
@@ -46,8 +46,8 @@ test_that("Functions accept rankings and rho as row or column vectors", {
     alpha_init, n_items,
     rankings = t(cluster_rankings),
     rho = rho_init,
-    leap_size,
-    metric
+    metric,
+    leap_size
   )
   mha_rt_r <- metropolis_hastings_alpha(
     alpha_init, n_items,
@@ -63,8 +63,8 @@ test_that("Functions accept rankings and rho as row or column vectors", {
     alpha_init, n_items,
     rankings = as.matrix(cluster_rankings),
     rho = t(rho_init),
-    leap_size,
-    metric
+    metric,
+    leap_size
   )
   mha_r_rt <- metropolis_hastings_alpha(
     alpha_init, n_items,
@@ -80,8 +80,8 @@ test_that("Functions accept rankings and rho as row or column vectors", {
     alpha_init, n_items,
     rankings = t(cluster_rankings),
     rho = t(rho_init),
-    leap_size,
-    metric
+    metric,
+    leap_size
   )
   mha_rt_rt <- metropolis_hastings_alpha(
     alpha_init, n_items,

--- a/tests/testthat/test-bulletproofing.R
+++ b/tests/testthat/test-bulletproofing.R
@@ -28,70 +28,70 @@ test_that("Functions accept rankings and rho as row or column vectors", {
   mhr_r_r <- metropolis_hastings_rho(
     alpha_init, n_items,
     rankings = as.matrix(cluster_rankings),
-    metric,
     rho = rho_init,
-    leap_size
+    leap_size,
+    metric
   )
   mha_r_r <- metropolis_hastings_alpha(
     alpha_init, n_items,
     rankings = as.matrix(cluster_rankings),
-    metric,
     rho = rho_init,
     logz_estimate,
     alpha_prop_sd,
     lambda,
-    alpha_max
+    alpha_max,
+    metric
   )
   mhr_rt_r <- metropolis_hastings_rho(
     alpha_init, n_items,
     rankings = t(cluster_rankings),
-    metric,
     rho = rho_init,
-    leap_size
+    leap_size,
+    metric
   )
   mha_rt_r <- metropolis_hastings_alpha(
     alpha_init, n_items,
     rankings = t(cluster_rankings),
-    metric,
     rho = rho_init,
     logz_estimate,
     alpha_prop_sd,
     lambda,
-    alpha_max
+    alpha_max,
+    metric
   )
   mhr_r_rt <- metropolis_hastings_rho(
     alpha_init, n_items,
     rankings = as.matrix(cluster_rankings),
-    metric,
     rho = t(rho_init),
-    leap_size
+    leap_size,
+    metric
   )
   mha_r_rt <- metropolis_hastings_alpha(
     alpha_init, n_items,
     rankings = as.matrix(cluster_rankings),
-    metric,
     rho = t(rho_init),
     logz_estimate,
     alpha_prop_sd,
     lambda,
-    alpha_max
+    alpha_max,
+    metric
   )
   mhr_rt_rt <- metropolis_hastings_rho(
     alpha_init, n_items,
     rankings = t(cluster_rankings),
-    metric,
     rho = t(rho_init),
-    leap_size
+    leap_size,
+    metric
   )
   mha_rt_rt <- metropolis_hastings_alpha(
     alpha_init, n_items,
     rankings = t(cluster_rankings),
-    metric,
     rho = t(rho_init),
     logz_estimate,
     alpha_prop_sd,
     lambda,
-    alpha_max
+    alpha_max,
+    metric
   )
   expect_equal(dim(mhr_r_r), c(10, 1))
   expect_length(mha_r_r, 1)

--- a/tests/testthat/test-bulletproofing.R
+++ b/tests/testthat/test-bulletproofing.R
@@ -37,10 +37,10 @@ test_that("Functions accept rankings and rho as row or column vectors", {
     rankings = as.matrix(cluster_rankings),
     rho = rho_init,
     logz_estimate,
-    alpha_prop_sd,
     lambda,
     alpha_max,
-    metric
+    metric,
+    alpha_prop_sd
   )
   mhr_rt_r <- metropolis_hastings_rho(
     alpha_init, n_items,
@@ -54,10 +54,10 @@ test_that("Functions accept rankings and rho as row or column vectors", {
     rankings = t(cluster_rankings),
     rho = rho_init,
     logz_estimate,
-    alpha_prop_sd,
     lambda,
     alpha_max,
-    metric
+    metric,
+    alpha_prop_sd
   )
   mhr_r_rt <- metropolis_hastings_rho(
     alpha_init, n_items,
@@ -71,10 +71,10 @@ test_that("Functions accept rankings and rho as row or column vectors", {
     rankings = as.matrix(cluster_rankings),
     rho = t(rho_init),
     logz_estimate,
-    alpha_prop_sd,
     lambda,
     alpha_max,
-    metric
+    metric,
+    alpha_prop_sd
   )
   mhr_rt_rt <- metropolis_hastings_rho(
     alpha_init, n_items,
@@ -88,10 +88,10 @@ test_that("Functions accept rankings and rho as row or column vectors", {
     rankings = t(cluster_rankings),
     rho = t(rho_init),
     logz_estimate,
-    alpha_prop_sd,
     lambda,
     alpha_max,
-    metric
+    metric,
+    alpha_prop_sd
   )
   expect_equal(dim(mhr_r_r), c(10, 1))
   expect_length(mha_r_r, 1)

--- a/tests/testthat/test-bulletproofing.R
+++ b/tests/testthat/test-bulletproofing.R
@@ -37,10 +37,10 @@ test_that("Functions accept rankings and rho as row or column vectors", {
     rankings = as.matrix(cluster_rankings),
     rho = rho_init,
     logz_estimate,
-    lambda,
     metric,
     alpha_prop_sd,
-    alpha_max
+    alpha_max,
+    lambda
   )
   mhr_rt_r <- metropolis_hastings_rho(
     alpha_init, n_items,
@@ -54,10 +54,10 @@ test_that("Functions accept rankings and rho as row or column vectors", {
     rankings = t(cluster_rankings),
     rho = rho_init,
     logz_estimate,
-    lambda,
     metric,
     alpha_prop_sd,
-    alpha_max
+    alpha_max,
+    lambda
   )
   mhr_r_rt <- metropolis_hastings_rho(
     alpha_init, n_items,
@@ -71,10 +71,10 @@ test_that("Functions accept rankings and rho as row or column vectors", {
     rankings = as.matrix(cluster_rankings),
     rho = t(rho_init),
     logz_estimate,
-    lambda,
     metric,
     alpha_prop_sd,
-    alpha_max
+    alpha_max,
+    lambda
   )
   mhr_rt_rt <- metropolis_hastings_rho(
     alpha_init, n_items,
@@ -88,10 +88,10 @@ test_that("Functions accept rankings and rho as row or column vectors", {
     rankings = t(cluster_rankings),
     rho = t(rho_init),
     logz_estimate,
-    lambda,
     metric,
     alpha_prop_sd,
-    alpha_max
+    alpha_max,
+    lambda
   )
   expect_equal(dim(mhr_r_r), c(10, 1))
   expect_length(mha_r_r, 1)

--- a/tests/testthat/test-smc_individual_functions.R
+++ b/tests/testthat/test-smc_individual_functions.R
@@ -170,27 +170,26 @@ logz_estimate <- estimate_partition_function(
 set.seed(101)
 test_1_a <- metropolis_hastings_alpha_old(alpha, n_items, rankings, metric, rho, logz_estimate)
 test_1_b <- metropolis_hastings_alpha(
-  alpha, n_items, rankings, metric, rho, logz_estimate,
-  alpha_prop_sd = 0.5,
-  lambda = 0.1, alpha_max = 20
+  alpha, n_items, rankings, rho, logz_estimate, alpha_prop_sd = 0.5,
+  lambda = 0.1, alpha_max = 20, metric
 )
 set.seed(101)
 test_2_a <- metropolis_hastings_alpha_old(
   alpha, n_items, rankings, metric, rho, logz_estimate
 )
 test_2_b <- metropolis_hastings_alpha(
-  alpha, n_items, rankings, metric, rho, logz_estimate,
-  alpha_prop_sd = 0.15, lambda = 0.1, alpha_max = 20
+  alpha, n_items, rankings, rho, logz_estimate, alpha_prop_sd = 0.15,
+  lambda = 0.1, alpha_max = 20, metric
 )
 set.seed(101)
 test_3_b <- metropolis_hastings_alpha(
-  alpha, n_items, rankings, metric, rho, logz_estimate,
-  alpha_prop_sd = 0.5, lambda = 0.15, alpha_max = 20
+  alpha, n_items, rankings, rho, logz_estimate, alpha_prop_sd = 0.5,
+  lambda = 0.15, alpha_max = 20, metric
 )
 set.seed(101)
 test_4_b <- metropolis_hastings_alpha(
-  alpha, n_items, rankings, metric, rho, logz_estimate,
-  alpha_prop_sd = 0.15, lambda = 0.15, alpha_max = 20
+  alpha, n_items, rankings, rho, logz_estimate, alpha_prop_sd = 0.15,
+  lambda = 0.15, alpha_max = 20, metric
 )
 
 test_that("metropolis_hastings_alpha() works as expected", {

--- a/tests/testthat/test-smc_mallows_new_item_rank.R
+++ b/tests/testthat/test-smc_mallows_new_item_rank.R
@@ -56,12 +56,13 @@ test_that("Produces the wrong metric and aug_method error", {
 })
 
 test_that("smc_mallows_new_item_rank_alpha_fixed is deprecated", {
-  expect_warning(smc_mallows_new_item_rank_alpha_fixed(
-    alpha = alpha_0, n_items = n_items, R_obs = sample_dataset,
-    metric = "footrule", leap_size = leap_size, N = N, Time = Time,
-    logz_estimate = logz_estimate, mcmc_kernel_app = mcmc_kernel_app,
-    alpha_prop_sd = alpha_prop_sd, lambda = lambda,
-    alpha_max = alpha_max, aug_method = "random"
+  expect_warning(
+    smc_mallows_new_item_rank_alpha_fixed(
+      alpha = alpha_0, n_items = n_items, R_obs = sample_dataset,
+      metric = "footrule", leap_size = leap_size, N = N, Time = Time,
+      logz_estimate = logz_estimate, mcmc_kernel_app = mcmc_kernel_app,
+      alpha_prop_sd = alpha_prop_sd, lambda = lambda,
+      alpha_max = alpha_max, aug_method = "random"
   ),
   "'smc_mallows_new_item_rank_alpha_fixed' is deprecated."
   )

--- a/tests/testthat/test-smc_pseudolikelihood.R
+++ b/tests/testthat/test-smc_pseudolikelihood.R
@@ -13,10 +13,10 @@ item_ordering <- c(3, 6, 4, 5)
 partial_ranking <- c(1, 2, NA, NA, NA, NA)
 remaining_set <- c(3, 4, 5, 6)
 test_1 <- get_sample_probabilities(
-  rho_item_rank = rho[3], alpha, remaining_set, metric, n_items
+  rho_item_rank = rho[3], alpha, remaining_set, n_items, metric
 )
 test_2 <- get_sample_probabilities(
-  rho_item_rank = rho[4], alpha, remaining_set, metric, n_items
+  rho_item_rank = rho[4], alpha, remaining_set, n_items, metric
 )
 
 test_that("get_sample_probabilities outputs as expected", {
@@ -81,14 +81,14 @@ test_that("M-H aug ranking pseudo works", {
   R_curr <- c(1, 2, 3, 4, 5, 6)
   R_obs <- c(1, 2, 3, 4, 5, 6)
   test_1 <- metropolis_hastings_aug_ranking(
-    alpha, rho, n_items, R_obs, R_curr, metric, TRUE
+    alpha, rho, n_items, R_obs, R_curr, TRUE, metric
   )
   expect_equal(test_1, matrix(c(1, 2, 3, 4, 5, 6)))
   expect_equal(all(test_1 == R_curr), TRUE)
   R_obs <- c(1, 2, 3, NA, NA, NA)
   set.seed(6220)
   test_2 <- metropolis_hastings_aug_ranking(
-    alpha, rho, n_items, R_obs, R_curr, metric, TRUE
+    alpha, rho, n_items, R_obs, R_curr, TRUE, metric
   )
   expect_equal(test_2, matrix(c(1, 2, 3, 5, 6, 4)))
   expect_equal(all(test_2 == R_curr), FALSE)
@@ -98,7 +98,7 @@ test_that("M-H aug ranking pseudo works", {
   test_3 <- metropolis_hastings_aug_ranking(
     alpha, rho, n_items,
     partial_ranking = R_obs, current_ranking = R_curr,
-    metric, TRUE
+    TRUE, metric
   )
   expect_equal(test_3, matrix(c(1, 2, 4, 3, 5, 6)))
   expect_equal(all(test_3 == R_curr), FALSE)


### PR DESCRIPTION
This aims to address the remaining task on issue #114. Merging this PR should be enough to close that issue, unless I missed something (which is rather possible, given the long discussion we had there :)). Further SMC DRYing should be taken care of in separate issues (#171, #257 or whatever else comes up later on).

@anjastein, thanks for checking if the default values proposed make sense in the SMC context: some where changed from the original SMC implementation (e.g. `alpha_prop_sd` was changed from 1 to 0.5 on `smc_mallows_new_users()`).

# Commit summary

- Updated documentation
- Matched SMC defaults with their original counterparts (#114)
- SMC metric defaults to footrule (#114)
- SMC leap_size defaults to 1 (#114)
- SMC alpha_prop_sd defaults to 0.5 (#114)
- SMC alpha_max defaults to 1e6 (#114)
- SMC lambda defautls to 0.1 (#114)