### PR TITLE
Attempted fix for LTO issue on some machines

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -380,7 +380,7 @@ BEGIN_RCPP
 END_RCPP
 }
 
-RcppExport SEXP run_testthat_tests(void *);
+RcppExport SEXP run_testthat_tests(SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
     {"_BayesMallows_get_rank_distance", (DL_FUNC) &_BayesMallows_get_rank_distance, 3},

--- a/tests/testthat/test-cpp.R
+++ b/tests/testthat/test-cpp.R
@@ -1,2 +1,4 @@
 set.seed(1)
-run_cpp_tests("BayesMallows")
+(function() {
+  .Call("run_testthat_tests", FALSE, PACKAGE = "BayesMallows")
+})


### PR DESCRIPTION
This solution is based on the suggested workaround from https://github.com/r-lib/testthat/issues/1230#issue-740555843.

That post also mentions manually editing RcppExports.cpp, but perhaps that's not necessary in our case, since we don't seem to be experiencing any change in `{"run_testthat_tests", (DL_FUNC) &run_testthat_tests, 1}` on any of our development machines.

@osorensen, please let me know if this helps, otherwise we can close the PR and try something else.
