### PR TITLE
Added BugReport URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BayesMallows
 Type: Package
 Title: Bayesian Preference Learning with the Mallows Rank Model
-Version: 1.3.2.9003
+Version: 1.3.2.9004
 Authors@R: c(person("Oystein", "Sorensen",
                     email = "oystein.sorensen.1985@gmail.com",
                     role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Authors@R: c(person("Oystein", "Sorensen",
 Maintainer: Oystein Sorensen <oystein.sorensen.1985@gmail.com>
 Description: An implementation of the Bayesian version of the Mallows rank model
     (Vitelli et al., Journal of Machine Learning Research, 2018 <https://jmlr.org/papers/v18/15-481.html>;
-    Crispino et al., Annals of Applied Statistics, 2019 <doi:10.1214/18-AOAS1203>; 
+    Crispino et al., Annals of Applied Statistics, 2019 <doi:10.1214/18-AOAS1203>;
     Sorensen et al., R Journal, 2020 <doi:10.32614/RJ-2020-026>;
     Stein, PhD Thesis, 2023 <https://eprints.lancs.ac.uk/id/eprint/195759>). Both Metropolis-Hastings
     and sequential Monte Carlo algorithms for estimating the models are available. Cayley, footrule,
@@ -41,6 +41,7 @@ Description: An implementation of the Bayesian version of the Mallows rank model
     sampling algorithm of Vitelli et al. and asymptotic approximation with the IPFP algorithm
     (Mukherjee, Annals of Statistics, 2016 <doi:10.1214/15-AOS1389>).
 URL: https://github.com/ocbe-uio/BayesMallows
+BugReports: https://github.com/ocbe-uio/BayesMallows/issues
 License: GPL-3
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
This should make it more clear where to report bug reports. It also makes the `bug.report(package = "BayesMallows")` command point to that URL instead of sending an e-mail to the maintainer (assuming anyone actually uses that command xD).
