### PR TITLE
Cleaner unit test output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BayesMallows
 Type: Package
 Title: Bayesian Preference Learning with the Mallows Rank Model
-Version: 1.3.2.9005
+Version: 1.3.2.9006
 Authors@R: c(person("Oystein", "Sorensen",
                     email = "oystein.sorensen.1985@gmail.com",
                     role = c("aut", "cre"),

--- a/tests/testthat/test-generate_transitive_closure.R
+++ b/tests/testthat/test-generate_transitive_closure.R
@@ -28,7 +28,7 @@ test_that("generate_transitive_closure works", {
 
   # This causes an error message and prints out the problematic rankings:
   expect_error(
-    generate_transitive_closure(pair_comp),
+    capture.output(generate_transitive_closure(pair_comp)),
     "Cannot compute transitive closure. Please run compute_mallows with error_model='bernoulli'."
   )
 })


### PR DESCRIPTION
Current local output of `devtools::testthat()` prints out part of the error message of `generate_transitive_closure()`:

![2023-10-03_15-32](https://github.com/ocbe-uio/BayesMallows/assets/8234768/064beff7-5f86-44cd-a706-6885c8a3f541)

Not a huge issue, but something that has bothered me enough to propose the fix on this PR:

![2023-10-03_15-46](https://github.com/ocbe-uio/BayesMallows/assets/8234768/7d430406-9556-43ca-8c03-b494ad326b93)
